### PR TITLE
feat(cli): add `wolfxl map` subcommand for one-page workbook overviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.5.0 (2026-04-19)
+
+### Added
+
+- **`wolfxl map <file>` subcommand**: one-page workbook overview for agents
+  that need to orient before fetching cell ranges. Emits per-sheet name,
+  dimensions, headers, anchored tables, and a coarse classification
+  (`empty` / `readme` / `summary` / `data`) plus workbook-level defined
+  names. Two output formats: `--format json` (default, machine-parseable)
+  and `--format text` (terminal-friendly, sectioned per sheet, header
+  preview capped at 8 columns with overflow count).
+- **`wolfxl-core::map` module**: `WorkbookMap`, `SheetMap`, `SheetClass`,
+  and the `classify_sheet` heuristic, callable from third-party Rust
+  consumers via the new `Workbook::map()` method.
+- `Workbook::named_ranges()` and `Workbook::table_names_in_sheet(name)`
+  pass-throughs to calamine's metadata accessors. Tables are now eagerly
+  loaded at `Workbook::open` so these accessors stay infallible (calamine
+  panics on `table_names*` without a prior `load_tables`).
+- Test-only `Sheet::from_rows_for_test` constructor (gated behind
+  `#[cfg(test)]`) so the classifier can exercise `Empty` / `Readme` /
+  sparse `Summary` branches that the committed xlsx fixtures don't hit.
+
+### Notes
+
+- The classifier intentionally does not look at merged cells (the upstream
+  PyO3 layer does, but `wolfxl-core` doesn't expose merge metadata yet).
+  A merged-title-row sheet today classifies as `summary` via the size +
+  density rule, which is the right answer for a typical dashboard.
+- Pivot detection is still out of scope — calamine doesn't surface pivot
+  parts directly, and the agent value of "this sheet is a pivot" is
+  marginal next to dimensions + headers.
+
 ## 0.4.0 (2026-04-19)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "wolfxl-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "wolfxl-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "calamine-styles",
  "chrono",

--- a/crates/wolfxl-cli/Cargo.toml
+++ b/crates/wolfxl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfxl-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,7 +14,7 @@ name = "wolfxl"
 path = "src/main.rs"
 
 [dependencies]
-wolfxl-core = { path = "../wolfxl-core", version = "0.4.0" }
+wolfxl-core = { path = "../wolfxl-core", version = "0.5.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 serde_json.workspace = true

--- a/crates/wolfxl-cli/src/commands/map.rs
+++ b/crates/wolfxl-cli/src/commands/map.rs
@@ -1,0 +1,88 @@
+//! `wolfxl map <file>` — workbook overview for agent orientation.
+//!
+//! Emits one record per sheet (name, dims, class, headers, anchored
+//! tables) plus workbook-level defined names. Two output formats:
+//!
+//! - `json` (default): machine-parseable, single-pass deserializable
+//! - `text`: terminal-friendly, sectioned per sheet
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use wolfxl_core::{Workbook, WorkbookMap};
+
+use crate::MapFormat;
+
+pub fn run(file: PathBuf, format: MapFormat) -> Result<()> {
+    let mut wb = Workbook::open(&file)
+        .with_context(|| format!("opening workbook {}", file.display()))?;
+    let map = wb
+        .map()
+        .with_context(|| format!("building map for {}", file.display()))?;
+
+    match format {
+        MapFormat::Json => print_json(&map)?,
+        MapFormat::Text => print_text(&map),
+    }
+    Ok(())
+}
+
+fn print_json(map: &WorkbookMap) -> Result<()> {
+    let value = json!({
+        "path": map.path,
+        "sheets": map.sheets.iter().map(|s| json!({
+            "name": s.name,
+            "rows": s.rows,
+            "cols": s.cols,
+            "class": s.class.as_str(),
+            "headers": s.headers,
+            "tables": s.tables,
+        })).collect::<Vec<Value>>(),
+        "named_ranges": map.named_ranges.iter().map(|(n, f)| json!({
+            "name": n,
+            "formula": f,
+        })).collect::<Vec<Value>>(),
+    });
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}
+
+fn print_text(map: &WorkbookMap) {
+    println!("workbook: {}", map.path);
+    println!("sheets:   {}", map.sheets.len());
+    if !map.named_ranges.is_empty() {
+        println!("named ranges: {}", map.named_ranges.len());
+    }
+    println!();
+    for s in &map.sheets {
+        println!("[{}] {}  ({} rows × {} cols)", s.class.as_str(), s.name, s.rows, s.cols);
+        if !s.headers.is_empty() {
+            // Truncate header preview at 8 columns to keep the per-sheet
+            // block short. A wide-table dump in a `map` view is noise —
+            // use `peek` for the full width.
+            let preview: Vec<String> = s
+                .headers
+                .iter()
+                .take(8)
+                .map(|h| if h.is_empty() { "∅".to_string() } else { h.clone() })
+                .collect();
+            let suffix = if s.headers.len() > 8 {
+                format!("  … (+{} more)", s.headers.len() - 8)
+            } else {
+                String::new()
+            };
+            println!("  headers: {}{}", preview.join(" | "), suffix);
+        }
+        if !s.tables.is_empty() {
+            println!("  tables:  {}", s.tables.join(", "));
+        }
+        println!();
+    }
+    if !map.named_ranges.is_empty() {
+        println!("named ranges:");
+        for (name, formula) in &map.named_ranges {
+            println!("  {} = {}", name, formula);
+        }
+    }
+}

--- a/crates/wolfxl-cli/src/commands/mod.rs
+++ b/crates/wolfxl-cli/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod map;
 pub mod peek;

--- a/crates/wolfxl-cli/src/main.rs
+++ b/crates/wolfxl-cli/src/main.rs
@@ -10,6 +10,7 @@ mod render;
 ///
 /// `wolfxl peek <file>` prints a styled, token-efficient view of a workbook —
 /// box / text / csv / json output, sheet selection, row and width caps.
+/// `wolfxl map <file>` prints a one-page summary of every sheet.
 #[derive(Parser, Debug)]
 #[command(name = "wolfxl", version, about, long_about = None)]
 struct Cli {
@@ -21,6 +22,24 @@ struct Cli {
 enum Command {
     /// Print a preview of a spreadsheet.
     Peek(PeekArgs),
+    /// Print a one-page workbook overview (sheets, dims, headers, named ranges).
+    Map(MapArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct MapArgs {
+    /// Path to the workbook (.xlsx).
+    file: PathBuf,
+
+    /// Output format.
+    #[arg(short = 'f', long = "format", default_value = "json")]
+    format: MapFormat,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum MapFormat {
+    Json,
+    Text,
 }
 
 #[derive(clap::Args, Debug)]
@@ -57,6 +76,7 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
     let result = match cli.command {
         Command::Peek(args) => commands::peek::run(args),
+        Command::Map(args) => commands::map::run(args.file, args.format),
     };
     match result {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/wolfxl-cli/tests/cli.rs
+++ b/crates/wolfxl-cli/tests/cli.rs
@@ -137,3 +137,42 @@ fn missing_file_errors() {
         .unwrap();
     assert!(!out.status.success());
 }
+
+#[test]
+fn map_text_lists_every_sheet_with_class_and_dims() {
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&["map", path.to_str().unwrap(), "--format", "text"]);
+    // All three sheets appear with their classification tag.
+    assert!(out.contains("[data] P&L  (21 rows × 7 cols)"), "missing P&L line: {out}");
+    assert!(out.contains("[data] Balance Sheet  (27 rows × 5 cols)"), "missing Balance Sheet line");
+    assert!(out.contains("[data] Revenue Breakdown  (13 rows × 7 cols)"), "missing Revenue line");
+    // Header preview surfaces the first column of P&L so callers can
+    // tell which sheet has which schema without a `peek`.
+    assert!(out.contains("Account | Jan 2024"), "missing P&L headers: {out}");
+}
+
+#[test]
+fn map_json_is_valid_and_has_expected_shape() {
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&["map", path.to_str().unwrap()]);
+    let value: serde_json::Value = serde_json::from_str(&out).expect("map JSON parses");
+    let sheets = value["sheets"].as_array().expect("sheets is array");
+    assert_eq!(sheets.len(), 3, "expected 3 sheets in sample-financials");
+    assert_eq!(sheets[0]["name"], "P&L");
+    assert_eq!(sheets[0]["rows"], 21);
+    assert_eq!(sheets[0]["cols"], 7);
+    assert_eq!(sheets[0]["class"], "data");
+    assert_eq!(sheets[0]["headers"][0], "Account");
+    assert!(value["named_ranges"].is_array(), "named_ranges field must exist");
+}
+
+#[test]
+fn map_handles_wide_table_with_truncated_header_preview() {
+    let path = fixture("wide-table.xlsx");
+    let out = run(&["map", path.to_str().unwrap(), "--format", "text"]);
+    // Wide table has 29 columns; text view caps the header preview at 8
+    // and reports the overflow count so an agent can decide whether to
+    // `peek` the full width.
+    assert!(out.contains("[data] Dept Operations  (25 rows × 29 cols)"), "missing dims: {out}");
+    assert!(out.contains("… (+21 more)"), "missing overflow marker: {out}");
+}

--- a/crates/wolfxl-core/Cargo.toml
+++ b/crates/wolfxl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfxl-core"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/wolfxl-core/src/lib.rs
+++ b/crates/wolfxl-core/src/lib.rs
@@ -28,11 +28,13 @@
 pub mod cell;
 pub mod error;
 pub mod format;
+pub mod map;
 pub mod sheet;
 pub mod workbook;
 
 pub use cell::{Cell, CellValue};
 pub use error::{Error, Result};
 pub use format::{FormatCategory, format_cell};
+pub use map::{SheetClass, SheetMap, WorkbookMap, classify_sheet};
 pub use sheet::Sheet;
 pub use workbook::Workbook;

--- a/crates/wolfxl-core/src/map.rs
+++ b/crates/wolfxl-core/src/map.rs
@@ -1,0 +1,163 @@
+//! Workbook map: one-page summary of every sheet (dimensions, headers,
+//! classification, anchored tables) plus workbook-level named ranges.
+//!
+//! The map exists for agents that need to *orient* before fetching cell
+//! ranges. Loading every sheet's full grid just to ask "which sheet has
+//! the data I want?" is the cost the map prevents.
+//!
+//! Build via [`Workbook::map`](crate::Workbook::map). Render to JSON or
+//! plain text in the consuming binary — `wolfxl-core` stays serde-free.
+
+use crate::cell::CellValue;
+use crate::sheet::Sheet;
+
+/// Coarse classification of a sheet's apparent purpose, derived from its
+/// value grid alone (no merged-cell or formula inspection).
+///
+/// Drives downstream prompt strategy: `Data` sheets justify a `peek`,
+/// `Readme` sheets often want a single-column dump, `Summary` sheets
+/// look formula-heavy with low fill density.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SheetClass {
+    Empty,
+    Readme,
+    Summary,
+    Data,
+}
+
+impl SheetClass {
+    /// Lowercase tag suitable for serialization or grep-friendly text.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SheetClass::Empty => "empty",
+            SheetClass::Readme => "readme",
+            SheetClass::Summary => "summary",
+            SheetClass::Data => "data",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SheetMap {
+    pub name: String,
+    pub rows: usize,
+    pub cols: usize,
+    pub class: SheetClass,
+    /// First-row contents, with empty cells preserved as `""` so column
+    /// position is meaningful for downstream consumers.
+    pub headers: Vec<String>,
+    /// Workbook tables (calamine `table_names_in_sheet`) anchored on this
+    /// sheet. Empty when the workbook defines no tables, which is the
+    /// common case for hand-authored sheets.
+    pub tables: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkbookMap {
+    pub path: String,
+    pub sheets: Vec<SheetMap>,
+    /// Workbook-level defined names as `(name, formula)` pairs, exactly
+    /// as calamine surfaces them. The formula string is a sheet+range
+    /// reference like `'P&L'!$A$1:$D$25` for typical named ranges.
+    pub named_ranges: Vec<(String, String)>,
+}
+
+/// Classify a sheet by shape and density. Pure value-grid heuristic — does
+/// not look at merged cells, formulas, or formatting.
+///
+/// Rules in priority order:
+/// 1. Zero rows or cols → `Empty`.
+/// 2. Exactly one column wide → `Readme` (notes-column convention).
+/// 3. Small (≤20 rows × ≤10 cols) AND fill density <40% → `Summary`
+///    (sparse formula sheets, dashboards, KPI panels).
+/// 4. Otherwise → `Data` (default for anything dense or large).
+pub fn classify_sheet(sheet: &Sheet) -> SheetClass {
+    let (rows, cols) = sheet.dimensions();
+    if rows == 0 || cols == 0 {
+        return SheetClass::Empty;
+    }
+    if cols == 1 {
+        return SheetClass::Readme;
+    }
+    let total = rows * cols;
+    let non_empty: usize = sheet
+        .rows()
+        .iter()
+        .map(|row| {
+            row.iter()
+                .filter(|c| !matches!(c.value, CellValue::Empty))
+                .count()
+        })
+        .sum();
+    let density = non_empty as f64 / total as f64;
+    if rows <= 20 && cols <= 10 && density < 0.4 {
+        return SheetClass::Summary;
+    }
+    SheetClass::Data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::Cell;
+
+    fn cell(s: &str) -> Cell {
+        Cell {
+            value: CellValue::String(s.to_string()),
+            number_format: None,
+        }
+    }
+
+    fn empty() -> Cell {
+        Cell::empty()
+    }
+
+    #[test]
+    fn empty_sheet_is_classified_empty() {
+        let sheet = Sheet::from_rows_for_test("blank", vec![]);
+        assert_eq!(classify_sheet(&sheet), SheetClass::Empty);
+    }
+
+    #[test]
+    fn single_column_sheet_is_classified_readme() {
+        // A notes column — multiple rows but one column wide.
+        let rows = (0..15)
+            .map(|i| vec![cell(&format!("note line {i}"))])
+            .collect();
+        let sheet = Sheet::from_rows_for_test("Notes", rows);
+        assert_eq!(classify_sheet(&sheet), SheetClass::Readme);
+    }
+
+    #[test]
+    fn small_sparse_sheet_is_classified_summary() {
+        // 5×5 with only a title and one KPI populated → density 2/25 = 8%,
+        // well under the 40% threshold; small enough on both axes.
+        let mut rows = vec![vec![empty(); 5]; 5];
+        rows[0][0] = cell("Q1 2026 Summary");
+        rows[2][1] = cell("$1.2M");
+        let sheet = Sheet::from_rows_for_test("Summary", rows);
+        assert_eq!(classify_sheet(&sheet), SheetClass::Summary);
+    }
+
+    #[test]
+    fn dense_rectangular_sheet_is_classified_data() {
+        // 10×5 fully populated grid → density 100%, defaults to Data.
+        let rows = (0..10)
+            .map(|r| (0..5).map(|c| cell(&format!("r{r}c{c}"))).collect())
+            .collect();
+        let sheet = Sheet::from_rows_for_test("Ledger", rows);
+        assert_eq!(classify_sheet(&sheet), SheetClass::Data);
+    }
+
+    #[test]
+    fn large_sheet_skips_summary_branch_even_if_sparse() {
+        // 50×15 mostly empty (only first cell filled) → density well under
+        // 40% but dimensions exceed the small-sheet gate, so falls
+        // through to Data. Without this rule, a giant mostly-empty data
+        // grid would mis-classify as Summary.
+        let mut rows = vec![vec![empty(); 15]; 50];
+        rows[0][0] = cell("seed");
+        let sheet = Sheet::from_rows_for_test("Big", rows);
+        assert_eq!(classify_sheet(&sheet), SheetClass::Data);
+    }
+}

--- a/crates/wolfxl-core/src/sheet.rs
+++ b/crates/wolfxl-core/src/sheet.rs
@@ -55,6 +55,18 @@ impl Sheet {
         (h, w)
     }
 
+    /// Test-only constructor: build a `Sheet` from a pre-shaped grid without
+    /// round-tripping through xlsx. Lets crate-internal tests (e.g. the
+    /// classifier in `map.rs`) cover branches the committed fixtures don't
+    /// exercise.
+    #[cfg(test)]
+    pub(crate) fn from_rows_for_test(name: &str, rows: Vec<Vec<Cell>>) -> Self {
+        Self {
+            name: name.to_string(),
+            rows,
+        }
+    }
+
     pub fn rows(&self) -> &[Vec<Cell>] {
         &self.rows
     }

--- a/crates/wolfxl-core/src/workbook.rs
+++ b/crates/wolfxl-core/src/workbook.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use calamine_styles::{Reader, Xlsx};
 
 use crate::error::{Error, Result};
+use crate::map::{SheetMap, WorkbookMap, classify_sheet};
 use crate::sheet::Sheet;
 
 type XlsxReader = Xlsx<BufReader<File>>;
@@ -20,8 +21,12 @@ impl Workbook {
         let path = path.as_ref().to_path_buf();
         let file = File::open(&path)?;
         let reader = BufReader::new(file);
-        let inner: XlsxReader =
+        let mut inner: XlsxReader =
             Xlsx::new(reader).map_err(|e| Error::Xlsx(format!("failed to parse xlsx: {e}")))?;
+        // calamine `table_names*` panic if tables haven't been loaded; load
+        // eagerly so downstream `&self` accessors stay infallible. The call
+        // is idempotent and cheap on workbooks without table parts.
+        let _ = inner.load_tables();
         let sheet_names = inner.sheet_names().to_vec();
         Ok(Self {
             inner,
@@ -55,5 +60,50 @@ impl Workbook {
             .ok_or_else(|| Error::SheetNotFound("(workbook has no sheets)".to_string()))?
             .clone();
         self.sheet(&name)
+    }
+
+    /// Workbook-level defined names as `(name, formula)` pairs, exactly
+    /// as calamine surfaces them.
+    pub fn named_ranges(&self) -> Vec<(String, String)> {
+        self.inner.defined_names().to_vec()
+    }
+
+    /// Names of workbook tables anchored on the given sheet. Empty when
+    /// the sheet has none, which is the common case.
+    pub fn table_names_in_sheet(&self, sheet_name: &str) -> Vec<String> {
+        self.inner
+            .table_names_in_sheet(sheet_name)
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Build a one-page summary: every sheet's dimensions, headers,
+    /// classification, and anchored tables, plus workbook-level defined
+    /// names. Loads each sheet eagerly to compute density for the
+    /// classifier — for huge workbooks the caller bears that IO cost.
+    pub fn map(&mut self) -> Result<WorkbookMap> {
+        let path = self.path.to_string_lossy().into_owned();
+        let named_ranges = self.named_ranges();
+        let names = self.sheet_names.clone();
+        let mut sheets = Vec::with_capacity(names.len());
+        for name in &names {
+            let tables = self.table_names_in_sheet(name);
+            let sheet = self.sheet(name)?;
+            let (rows, cols) = sheet.dimensions();
+            sheets.push(SheetMap {
+                name: name.clone(),
+                rows,
+                cols,
+                class: classify_sheet(&sheet),
+                headers: sheet.headers(),
+                tables,
+            });
+        }
+        Ok(WorkbookMap {
+            path,
+            sheets,
+            named_ranges,
+        })
     }
 }


### PR DESCRIPTION
## What

New \`wolfxl map <file>\` subcommand that emits a one-page summary of every sheet in a workbook — name, dimensions, headers, anchored tables, plus a coarse class (\`empty\` / \`readme\` / \`summary\` / \`data\`) and workbook-level defined names.

## Why

Agents that need to orient before fetching cell ranges currently have to load every sheet's full grid just to ask "which sheet has the data I want?" A \`map\` is dramatically cheaper than a multi-\`peek\` survey, and it's the foundation for the upcoming \`--agent --max-tokens\` mode (sprint 2 step 8) which needs to know sheet shapes before composing a token-budgeted view.

## Output

\`\`\`
$ wolfxl map examples/sample-financials.xlsx --format text
workbook: examples/sample-financials.xlsx
sheets:   3

[data] P&L  (21 rows × 7 cols)
  headers: Account | Jan 2024 | Feb 2024 | Mar 2024 | Q1 Total | Q1 2023 | YoY %

[data] Balance Sheet  (27 rows × 5 cols)
  headers: Account | Mar 31 2024 | Dec 31 2023 | Change \$ | Change %

[data] Revenue Breakdown  (13 rows × 7 cols)
  headers: Customer | Segment | Jan | Feb | Mar | Q1 Total | % of Total
\`\`\`

JSON output (default) is the agent-canonical form: \`{path, sheets[], named_ranges[]}\` with stable per-sheet keys \`{name, rows, cols, class, headers, tables}\`.

## Implementation

- New \`wolfxl-core::map\` module with \`WorkbookMap\`, \`SheetMap\`, \`SheetClass\`, and a pure value-grid \`classify_sheet\` heuristic.
- \`Workbook::map()\` ties it all together. New \`named_ranges()\` and \`table_names_in_sheet()\` pass-throughs to calamine.
- Tables are eagerly loaded at \`Workbook::open\` (calamine's \`table_names*\` panics if \`load_tables\` hasn't been called — idempotent, cheap on workbooks without table parts).
- New CLI dispatch + \`commands/map.rs\` for JSON / text rendering.
- Test-only \`Sheet::from_rows_for_test\` (cfg-test) lets the classifier exercise \`Empty\` / \`Readme\` / sparse \`Summary\` branches without committing extra xlsx fixtures.

## Out of scope (deferred)

- **Pivots**: calamine doesn't surface pivot parts directly, and "this is a pivot" is marginal value next to dims + headers.
- **Merged-cell-aware classification**: the upstream PyO3 layer reads merges; \`wolfxl-core\` doesn't expose them yet. A merged-title-row dashboard today classifies as \`summary\` via the size + density rule, which is the right answer.
- **\`--agent --max-tokens\` and \`--schema\`** are next sprint-2 commits, not bundled here.

## Versions

- \`wolfxl-core\` 0.4.0 → **0.5.0** (additive: new \`map\` module, new \`Workbook\` methods)
- \`wolfxl-cli\` 0.4.0 → **0.5.0** (additive: new \`map\` subcommand)

Pre-1.0 minor bump for additive public API on both.

## Test plan

- [x] \`cargo test -p wolfxl-core -p wolfxl-cli\` — 18 core unit + 1 integration + 1 doctest + 6 cli render unit + 14 cli integration (3 new for \`map\`)
- [x] Smoke-tested against \`sample-financials.xlsx\` (3 sheets, all classified \`data\`, headers + dims correct) and \`wide-table.xlsx\` (29 cols, header preview truncates at 8 with \`+21 more\` overflow tag)
- [x] Empty / Readme / sparse Summary / dense Data classifier branches all green via unit tests with synthetic grids
- [x] JSON output round-trips through \`serde_json::from_str\` cleanly