### PR TITLE
feat(cli): add `wolfxl agent` subcommand for token-budgeted briefings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.6.0 (2026-04-19)
+
+### Added
+
+- **`wolfxl agent <file> --max-tokens N` subcommand**: composes a
+  token-budgeted workbook briefing for an LLM context window. Emits a
+  workbook overview (every sheet with dims/class/first-column header),
+  picks the largest `data`-class sheet (or `--sheet` override), then
+  greedily fills the remaining budget with header row, head 3 rows, tail
+  2 rows, and up to 8 stratified middle samples. Token counts use
+  `tiktoken-rs::cl100k_base` to match the GPT-4 family tokenizer (and
+  `spreadsheet-peek/benchmarks/measure_tokens.py`); verified at 0-token
+  drift against Python `tiktoken`. Falls back to orientation-only output
+  if the budget is too tight (and reports the overage in the footer
+  rather than silently truncating).
+- **Stratified row sampling**: head + tail + uniform-stride middle
+  samples instead of head-only. An LLM seeing rows 1, 2, 3 of a 50-row
+  P&L can't tell totals from line items; rows 1-3, 25-26, 49-50 plus
+  middle samples surface the shape of the data.
+- **Token budget tracker**: `Budget::used_with(buf, section)` re-encodes
+  the full concatenation rather than summing per-section counts, because
+  cl100k_base BPE merges across boundaries (additive checks would
+  over-count and reject sections that actually fit).
+
+### Notes
+
+- `--agent` deliberately does NOT thousand-group integers (`1234567`,
+  not `1,234,567`). Every comma is a token boundary in cl100k_base, so
+  ungrouped costs ~2 tokens vs grouped ~5 for the same number. Pretty
+  output costs the agent context.
+- The orientation core (workbook overview + sheet header + columns) is
+  emitted even when it overflows the budget. We'd rather report the
+  overage in the footer than hide workbook structure from the agent.
+
 ## 0.5.0 (2026-04-19)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +339,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +457,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -653,6 +691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +803,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -923,13 +982,14 @@ dependencies = [
 
 [[package]]
 name = "wolfxl-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
  "predicates",
  "serde_json",
+ "tiktoken-rs",
  "unicode-width",
  "wolfxl-core",
 ]

--- a/crates/wolfxl-cli/Cargo.toml
+++ b/crates/wolfxl-cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wolfxl-cli"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Excel xlsx previewer. Installs the `wolfxl` binary with a `peek` subcommand for box/text/csv/json output."
+description = "Excel xlsx previewer for AI agents. Installs the `wolfxl` binary with `peek` (styled previews), `map` (workbook overview), and `agent` (token-budgeted briefing) subcommands."
 readme = "README.md"
 keywords = ["xlsx", "excel", "cli", "preview", "spreadsheet"]
 categories = ["command-line-utilities", "visualization"]
@@ -19,6 +19,7 @@ clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 serde_json.workspace = true
 unicode-width = "0.2"
+tiktoken-rs = "0.11.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/wolfxl-cli/src/commands/agent.rs
+++ b/crates/wolfxl-cli/src/commands/agent.rs
@@ -1,0 +1,429 @@
+//! `wolfxl agent <file> --max-tokens N` — token-budgeted workbook briefing.
+//!
+//! The brief is composed greedily for an LLM context window. Priority order:
+//! 1. Workbook overview (every sheet, dims + class + first-column header)
+//! 2. Focused sheet header (chosen sheet, dims, class)
+//! 3. Column headers for the focused sheet
+//! 4. Head rows (first 3) — ordering tends to be authored, so head matters
+//! 5. Tail rows (last 2) — totals/EPS/footnotes typically live at the bottom
+//! 6. Stratified middle samples — fills remaining budget with diverse rows
+//! 7. Footer line: `# wolfxl agent: USED/LIMIT tokens (cl100k_base)`
+//!
+//! Block 1+2+3 is the orientation core and is emitted even if the row blocks
+//! get dropped. If even the orientation core overflows, we still emit it
+//! (truncating the budget would defeat the purpose of telling the agent what
+//! sheets exist) and the footer reports the overage so the caller knows.
+//!
+//! Token counts use `tiktoken-rs::cl100k_base` to match the GPT-4 family
+//! tokenizer used by `spreadsheet-peek/benchmarks/measure_tokens.py`.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use tiktoken_rs::{cl100k_base_singleton, CoreBPE};
+use wolfxl_core::{Cell, CellValue, Sheet, SheetClass, Workbook, WorkbookMap};
+
+pub fn run(file: PathBuf, max_tokens: usize, target_sheet: Option<String>) -> Result<()> {
+    let mut wb = Workbook::open(&file)
+        .with_context(|| format!("opening workbook: {}", file.display()))?;
+    let map = wb.map().context("building workbook map")?;
+    let target = pick_target(&map, target_sheet.as_deref())?;
+    let sheet = wb
+        .sheet(&target)
+        .with_context(|| format!("loading sheet {target:?}"))?;
+
+    let bpe = cl100k_base_singleton();
+    let budget = Budget::new(bpe, max_tokens);
+    let mut buf = String::new();
+
+    // Orientation core (overview + sheet header + columns) always lands,
+    // even if it overflows — we'd rather report overage in the footer than
+    // hide the workbook structure from the agent.
+    write_overview(&mut buf, &map);
+    write_sheet_header(&mut buf, &target, &sheet, &map);
+
+    write_rows(&mut buf, &sheet, &budget);
+
+    let footer = format!(
+        "\n# wolfxl agent: {used}/{limit} tokens (cl100k_base)\n",
+        used = budget.used(&buf),
+        limit = max_tokens
+    );
+    buf.push_str(&footer);
+
+    io::stdout().lock().write_all(buf.as_bytes())?;
+    Ok(())
+}
+
+/// Pick the focus sheet. Explicit `--sheet` wins; otherwise prefer the
+/// largest `Data` sheet by row count, falling back to the first sheet so
+/// workbooks of all-summary or all-empty shape still produce output.
+fn pick_target(map: &WorkbookMap, requested: Option<&str>) -> Result<String> {
+    if let Some(name) = requested {
+        if !map.sheets.iter().any(|s| s.name == name) {
+            let names: Vec<&str> = map.sheets.iter().map(|s| s.name.as_str()).collect();
+            anyhow::bail!("sheet {name:?} not found; available: {}", names.join(", "));
+        }
+        return Ok(name.to_string());
+    }
+    let best_data = map
+        .sheets
+        .iter()
+        .filter(|s| s.class == SheetClass::Data)
+        .max_by_key(|s| s.rows);
+    if let Some(s) = best_data {
+        return Ok(s.name.clone());
+    }
+    map.sheets
+        .first()
+        .map(|s| s.name.clone())
+        .ok_or_else(|| anyhow::anyhow!("workbook has no sheets"))
+}
+
+fn write_overview(buf: &mut String, map: &WorkbookMap) {
+    let path = std::path::Path::new(&map.path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&map.path);
+    buf.push_str(&format!("WORKBOOK: {path}\n"));
+    buf.push_str("SHEETS:\n");
+    for s in &map.sheets {
+        let first_col = s.headers.first().map(String::as_str).unwrap_or("");
+        if first_col.is_empty() {
+            buf.push_str(&format!(
+                "  - {name} ({rows}r×{cols}c) [{class}]\n",
+                name = s.name,
+                rows = s.rows,
+                cols = s.cols,
+                class = s.class.as_str()
+            ));
+        } else {
+            buf.push_str(&format!(
+                "  - {name} ({rows}r×{cols}c) [{class}] col1={first_col:?}\n",
+                name = s.name,
+                rows = s.rows,
+                cols = s.cols,
+                class = s.class.as_str()
+            ));
+        }
+    }
+    if !map.named_ranges.is_empty() {
+        buf.push_str("NAMED_RANGES:\n");
+        for (name, formula) in &map.named_ranges {
+            buf.push_str(&format!("  - {name} = {formula}\n"));
+        }
+    }
+}
+
+fn write_sheet_header(buf: &mut String, target: &str, sheet: &Sheet, map: &WorkbookMap) {
+    let (rows, cols) = sheet.dimensions();
+    let class = map
+        .sheets
+        .iter()
+        .find(|s| s.name == target)
+        .map(|s| s.class.as_str())
+        .unwrap_or("data");
+    buf.push('\n');
+    buf.push_str(&format!(
+        "SHEET: {target}  [{class}]  {rows} rows × {cols} cols\n"
+    ));
+    let headers = sheet.headers();
+    if !headers.is_empty() {
+        buf.push_str("HEADERS: ");
+        buf.push_str(&headers.join("\t"));
+        buf.push('\n');
+    }
+}
+
+/// Emit head + tail + middle stratified samples within the remaining budget.
+/// The body is `sheet.rows()[1..]` (header is row 0).
+fn write_rows(buf: &mut String, sheet: &Sheet, budget: &Budget) {
+    let body_start = 1usize;
+    let total = sheet.rows().len();
+    if total <= body_start {
+        return;
+    }
+    let body_count = total - body_start;
+    let head_n = 3.min(body_count);
+    let tail_n = if body_count > head_n { 2.min(body_count - head_n) } else { 0 };
+
+    // Head: emit all-or-nothing as a labelled block. If the section overflows
+    // we'd rather skip than half-emit (truncated rows lie about row count).
+    let head_section = render_section(
+        sheet,
+        body_start,
+        body_start + head_n,
+        &format!("ROWS (head {head_n} of {body_count}):"),
+    );
+    try_append(buf, budget, &head_section);
+
+    if tail_n > 0 {
+        let start = total - tail_n;
+        let tail_section = render_section(
+            sheet,
+            start,
+            total,
+            &format!("ROWS (tail {tail_n} of {body_count}):"),
+        );
+        try_append(buf, budget, &tail_section);
+    }
+
+    let middle_lo = body_start + head_n;
+    let middle_hi = total.saturating_sub(tail_n);
+    if middle_hi > middle_lo {
+        let middle_count = middle_hi - middle_lo;
+        emit_stratified_middle(buf, sheet, budget, middle_lo, middle_count);
+    }
+}
+
+/// Stratification = uniform stride. For a 10-row middle and 4 picks we'd
+/// take indices [0, 3, 6, 9]. Caller supplies `lo` (absolute row index) and
+/// `middle_count` (the size of the middle window).
+///
+/// We try up to 8 picks (cap on visual noise + budget reasonableness) and
+/// emit them one at a time. The header line lands first; if even the
+/// header overflows the row block is skipped entirely.
+fn emit_stratified_middle(
+    buf: &mut String,
+    sheet: &Sheet,
+    budget: &Budget,
+    lo: usize,
+    middle_count: usize,
+) {
+    let target_picks = 8usize.min(middle_count);
+    if target_picks == 0 {
+        return;
+    }
+
+    let mut picks: Vec<usize> = Vec::with_capacity(target_picks);
+    if target_picks == 1 {
+        picks.push(lo + middle_count / 2);
+    } else {
+        for i in 0..target_picks {
+            let off = (i as f64) * ((middle_count - 1) as f64) / ((target_picks - 1) as f64);
+            let row_idx = lo + (off.round() as usize);
+            if !picks.contains(&row_idx) {
+                picks.push(row_idx);
+            }
+        }
+    }
+
+    let header = format!(
+        "ROWS (middle stratified, up to {} of {}):\n",
+        picks.len(),
+        middle_count
+    );
+    if !try_append(buf, budget, &header) {
+        return;
+    }
+    for idx in picks {
+        let line = format!("  {}\n", row_as_tsv(&sheet.rows()[idx]));
+        if !try_append(buf, budget, &line) {
+            break;
+        }
+    }
+}
+
+fn render_section(sheet: &Sheet, lo: usize, hi: usize, label: &str) -> String {
+    let mut out = String::new();
+    out.push_str(label);
+    out.push('\n');
+    for row in &sheet.rows()[lo..hi] {
+        out.push_str("  ");
+        out.push_str(&row_as_tsv(row));
+        out.push('\n');
+    }
+    out
+}
+
+/// Append `section` to `buf` only if doing so keeps the running token count
+/// under budget. Returns whether the section landed.
+///
+/// We probe by counting `buf + section` rather than `used(buf) + count(section)`
+/// because cl100k_base BPE merges across boundaries — a token boundary that
+/// sits at the seam can collapse two pieces into one. Sub-additive merge
+/// would let an additive check reject sections that would actually fit.
+fn try_append(buf: &mut String, budget: &Budget, section: &str) -> bool {
+    let candidate_used = budget.used_with(buf, section);
+    if candidate_used > budget.limit {
+        return false;
+    }
+    buf.push_str(section);
+    true
+}
+
+fn row_as_tsv(row: &[Cell]) -> String {
+    row.iter()
+        .map(|c| display_cell(c))
+        .collect::<Vec<_>>()
+        .join("\t")
+}
+
+/// Compact text rendering for the agent brief. We deliberately do NOT
+/// thousand-group integers here: every comma is a token boundary in
+/// cl100k_base, so `1234567` is two tokens but `1,234,567` is five. The
+/// agent doesn't need pretty output; it needs cheap output.
+fn display_cell(cell: &Cell) -> String {
+    match &cell.value {
+        CellValue::Empty => String::new(),
+        CellValue::String(s) => s.clone(),
+        CellValue::Bool(b) => if *b { "true" } else { "false" }.to_string(),
+        CellValue::Int(n) => n.to_string(),
+        CellValue::Float(n) => {
+            if n.is_finite() && n.fract() == 0.0 && n.abs() < 1e15 {
+                format!("{n:.0}")
+            } else if n.is_finite() {
+                format!("{n:.2}")
+            } else {
+                n.to_string()
+            }
+        }
+        CellValue::Date(d) => d.format("%Y-%m-%d").to_string(),
+        CellValue::DateTime(dt) => dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
+        CellValue::Time(t) => t.format("%H:%M:%S").to_string(),
+        CellValue::Error(e) => format!("ERR:{e}"),
+    }
+}
+
+/// Token budget tracker. Wraps `cl100k_base` and tracks the running total
+/// of tokens emitted so far. `consume(s)` returns the token count of `s`
+/// (so callers can decide whether to commit it); `remaining()` returns
+/// what's left given the latest `used()` recompute.
+///
+/// Implementation note: we recount the whole accumulated buffer in
+/// `used()` rather than incrementing per-add. BPE is *not* additive —
+/// `tokens(a + b) <= tokens(a) + tokens(b)` because adjacent pieces can
+/// merge into a single token across the boundary. Recomputing on the
+/// final buffer is the only way to get a count that matches what
+/// `tiktoken.cl100k_base.encode(full_output)` will produce.
+struct Budget<'a> {
+    bpe: &'a CoreBPE,
+    limit: usize,
+}
+
+impl<'a> Budget<'a> {
+    fn new(bpe: &'a CoreBPE, limit: usize) -> Self {
+        Self { bpe, limit }
+    }
+
+    /// Total tokens an accumulated buffer would cost (matches what
+    /// `tiktoken.cl100k_base.encode(buf)` returns in Python).
+    fn used(&self, buf: &str) -> usize {
+        self.bpe.encode_ordinary(buf).len()
+    }
+
+    /// Tokens of `buf + section`, encoded as one piece so cross-boundary
+    /// BPE merges are counted correctly. Cheaper allocations would split
+    /// the encode but lose merge accuracy at the seam.
+    fn used_with(&self, buf: &str, section: &str) -> usize {
+        // Re-encoding the full concatenation is the only way to get the
+        // exact final count; BPE is non-additive at piece boundaries.
+        let mut probe = String::with_capacity(buf.len() + section.len());
+        probe.push_str(buf);
+        probe.push_str(section);
+        self.bpe.encode_ordinary(&probe).len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wolfxl_core::SheetMap;
+
+    #[test]
+    fn budget_recomputes_against_full_buffer() {
+        // BPE is non-additive across boundaries; `used_with` re-encodes
+        // the full concatenation so cross-seam merges are counted. An
+        // additive `count(a) + count(b)` would over-count and reject
+        // sections that actually fit.
+        let bpe = cl100k_base_singleton();
+        let b = Budget::new(bpe, 100);
+        let combined = b.used("hello world");
+        let with = b.used_with("hello", " world");
+        assert_eq!(combined, with);
+    }
+
+    #[test]
+    fn pick_target_prefers_largest_data_sheet() {
+        // Build a synthetic WorkbookMap with three sheets of different
+        // sizes and classes; the largest-by-rows Data sheet wins even if
+        // a Summary sheet has more rows.
+        let map = WorkbookMap {
+            path: "test.xlsx".to_string(),
+            sheets: vec![
+                SheetMap {
+                    name: "Notes".to_string(),
+                    rows: 50,
+                    cols: 1,
+                    class: SheetClass::Readme,
+                    headers: vec!["note".to_string()],
+                    tables: vec![],
+                },
+                SheetMap {
+                    name: "P&L".to_string(),
+                    rows: 21,
+                    cols: 7,
+                    class: SheetClass::Data,
+                    headers: vec![],
+                    tables: vec![],
+                },
+                SheetMap {
+                    name: "Detail".to_string(),
+                    rows: 200,
+                    cols: 12,
+                    class: SheetClass::Data,
+                    headers: vec![],
+                    tables: vec![],
+                },
+            ],
+            named_ranges: vec![],
+        };
+        assert_eq!(pick_target(&map, None).unwrap(), "Detail");
+    }
+
+    #[test]
+    fn pick_target_falls_back_to_first_sheet_when_no_data() {
+        let map = WorkbookMap {
+            path: "test.xlsx".to_string(),
+            sheets: vec![
+                SheetMap {
+                    name: "Cover".to_string(),
+                    rows: 5,
+                    cols: 1,
+                    class: SheetClass::Readme,
+                    headers: vec![],
+                    tables: vec![],
+                },
+                SheetMap {
+                    name: "Summary".to_string(),
+                    rows: 10,
+                    cols: 4,
+                    class: SheetClass::Summary,
+                    headers: vec![],
+                    tables: vec![],
+                },
+            ],
+            named_ranges: vec![],
+        };
+        assert_eq!(pick_target(&map, None).unwrap(), "Cover");
+    }
+
+    #[test]
+    fn pick_target_explicit_wins_over_heuristic() {
+        let map = WorkbookMap {
+            path: "test.xlsx".to_string(),
+            sheets: vec![SheetMap {
+                name: "P&L".to_string(),
+                rows: 21,
+                cols: 7,
+                class: SheetClass::Data,
+                headers: vec![],
+                tables: vec![],
+            }],
+            named_ranges: vec![],
+        };
+        assert_eq!(pick_target(&map, Some("P&L")).unwrap(), "P&L");
+        assert!(pick_target(&map, Some("Nope")).is_err());
+    }
+}

--- a/crates/wolfxl-cli/src/commands/agent.rs
+++ b/crates/wolfxl-cli/src/commands/agent.rs
@@ -4,15 +4,21 @@
 //! 1. Workbook overview (every sheet, dims + class + first-column header)
 //! 2. Focused sheet header (chosen sheet, dims, class)
 //! 3. Column headers for the focused sheet
-//! 4. Head rows (first 3) — ordering tends to be authored, so head matters
-//! 5. Tail rows (last 2) — totals/EPS/footnotes typically live at the bottom
-//! 6. Stratified middle samples — fills remaining budget with diverse rows
-//! 7. Footer line: `# wolfxl agent: USED/LIMIT tokens (cl100k_base)`
+//! 4. Named ranges (capped, budgeted — drops first if budget is tight)
+//! 5. Head rows (first 3) — ordering tends to be authored, so head matters
+//! 6. Tail rows (last 2) — totals/EPS/footnotes typically live at the bottom
+//! 7. Stratified middle samples — fills remaining budget with diverse rows
+//! 8. Footer line: `# wolfxl agent: USED/LIMIT tokens (cl100k_base)`
 //!
 //! Block 1+2+3 is the orientation core and is emitted even if the row blocks
 //! get dropped. If even the orientation core overflows, we still emit it
 //! (truncating the budget would defeat the purpose of telling the agent what
 //! sheets exist) and the footer reports the overage so the caller knows.
+//!
+//! Footer tokens count toward the budget. We reserve a worst-case footer
+//! cost up-front (so body composition stops early enough), and the final
+//! printed `USED` value re-encodes `body + footer` so the reported number
+//! matches what `tiktoken.cl100k_base.encode(stdout)` returns.
 //!
 //! Token counts use `tiktoken-rs::cl100k_base` to match the GPT-4 family
 //! tokenizer used by `spreadsheet-peek/benchmarks/measure_tokens.py`.
@@ -43,17 +49,35 @@ pub fn run(file: PathBuf, max_tokens: usize, target_sheet: Option<String>) -> Re
     write_overview(&mut buf, &map);
     write_sheet_header(&mut buf, &target, &sheet, &map);
 
+    // Named ranges are best-effort: emitted via try_append so they drop
+    // first when the budget is tight. They live between the orientation
+    // core and the row blocks so they get priority over samples but never
+    // crowd out columns.
+    write_named_ranges(&mut buf, &budget, &map);
+
     write_rows(&mut buf, &sheet, &budget);
 
-    let footer = format!(
-        "\n# wolfxl agent: {used}/{limit} tokens (cl100k_base)\n",
-        used = budget.used(&buf),
-        limit = max_tokens
-    );
-    buf.push_str(&footer);
+    // The footer reports `body+footer` tokens. Because the printed `used`
+    // value is itself part of the footer, we iterate to a fixed point: in
+    // practice this converges in 1-2 passes since cl100k_base token counts
+    // are stable across small changes in the digit length of the numerator.
+    let mut reported = budget.used(&buf);
+    for _ in 0..3 {
+        let probe = format_footer(reported, budget.limit);
+        let total = budget.used_with(&buf, &probe);
+        if total == reported {
+            break;
+        }
+        reported = total;
+    }
+    buf.push_str(&format_footer(reported, budget.limit));
 
     io::stdout().lock().write_all(buf.as_bytes())?;
     Ok(())
+}
+
+fn format_footer(used: usize, limit: usize) -> String {
+    format!("\n# wolfxl agent: {used}/{limit} tokens (cl100k_base)\n")
 }
 
 /// Pick the focus sheet. Explicit `--sheet` wins; otherwise prefer the
@@ -108,12 +132,27 @@ fn write_overview(buf: &mut String, map: &WorkbookMap) {
             ));
         }
     }
-    if !map.named_ranges.is_empty() {
-        buf.push_str("NAMED_RANGES:\n");
-        for (name, formula) in &map.named_ranges {
-            buf.push_str(&format!("  - {name} = {formula}\n"));
-        }
+}
+
+/// Best-effort named-ranges section. Capped at 8 entries so a workbook
+/// with 200 named ranges can't single-handedly drain the budget; longer
+/// lists get a `… (+N more)` overflow marker. The whole section is also
+/// gated through `try_append`, so under tight budgets it drops cleanly
+/// and never partially emits.
+fn write_named_ranges(buf: &mut String, budget: &Budget, map: &WorkbookMap) {
+    if map.named_ranges.is_empty() {
+        return;
     }
+    const MAX: usize = 8;
+    let total = map.named_ranges.len();
+    let mut section = String::from("\nNAMED_RANGES:\n");
+    for (name, formula) in map.named_ranges.iter().take(MAX) {
+        section.push_str(&format!("  - {name} = {formula}\n"));
+    }
+    if total > MAX {
+        section.push_str(&format!("  … (+{} more)\n", total - MAX));
+    }
+    try_append(buf, budget, &section);
 }
 
 fn write_sheet_header(buf: &mut String, target: &str, sheet: &Sheet, map: &WorkbookMap) {
@@ -128,10 +167,16 @@ fn write_sheet_header(buf: &mut String, target: &str, sheet: &Sheet, map: &Workb
     buf.push_str(&format!(
         "SHEET: {target}  [{class}]  {rows} rows × {cols} cols\n"
     ));
+    // Headers may come back as a vector of empty strings when the first
+    // row of a sheet has no header values (e.g., a sparse summary). In
+    // that case a `HEADERS:\t\t\t\t` line burns tokens for no signal —
+    // skip it. We also trim trailing empties so wide tables with mostly
+    // unlabelled trailing columns don't pad the line with noise tabs.
     let headers = sheet.headers();
-    if !headers.is_empty() {
+    if let Some(end) = headers.iter().rposition(|h| !h.is_empty()) {
+        let trimmed = &headers[..=end];
         buf.push_str("HEADERS: ");
-        buf.push_str(&headers.join("\t"));
+        buf.push_str(&trimmed.join("\t"));
         buf.push('\n');
     }
 }
@@ -244,9 +289,13 @@ fn render_section(sheet: &Sheet, lo: usize, hi: usize, label: &str) -> String {
 /// because cl100k_base BPE merges across boundaries — a token boundary that
 /// sits at the seam can collapse two pieces into one. Sub-additive merge
 /// would let an additive check reject sections that would actually fit.
+///
+/// The check is against `body_limit`, not `limit`: `body_limit` reserves
+/// space for the (yet-to-be-appended) footer line so the total emission
+/// honors `--max-tokens N`.
 fn try_append(buf: &mut String, budget: &Budget, section: &str) -> bool {
     let candidate_used = budget.used_with(buf, section);
-    if candidate_used > budget.limit {
+    if candidate_used > budget.body_limit {
         return false;
     }
     buf.push_str(section);
@@ -286,25 +335,40 @@ fn display_cell(cell: &Cell) -> String {
     }
 }
 
-/// Token budget tracker. Wraps `cl100k_base` and tracks the running total
-/// of tokens emitted so far. `consume(s)` returns the token count of `s`
-/// (so callers can decide whether to commit it); `remaining()` returns
-/// what's left given the latest `used()` recompute.
+/// Stateless token-budget projection. Wraps `cl100k_base` and exposes
+/// two queries: `used(buf)` re-encodes the buffer end-to-end, and
+/// `used_with(buf, section)` re-encodes `buf + section` (used by
+/// `try_append` to predict the cost of a candidate section).
 ///
-/// Implementation note: we recount the whole accumulated buffer in
-/// `used()` rather than incrementing per-add. BPE is *not* additive —
-/// `tokens(a + b) <= tokens(a) + tokens(b)` because adjacent pieces can
-/// merge into a single token across the boundary. Recomputing on the
-/// final buffer is the only way to get a count that matches what
-/// `tiktoken.cl100k_base.encode(full_output)` will produce.
+/// `limit` is the user-supplied `--max-tokens N`. `body_limit` is
+/// `limit - footer_reserve`, where `footer_reserve` is the worst-case
+/// token cost of the trailing `# wolfxl agent: USED/LIMIT ...` line.
+/// `try_append` checks against `body_limit` so the final emission
+/// (body + footer) honors the user's limit.
+///
+/// We re-encode the whole accumulated buffer rather than incrementing
+/// per-add because BPE is *not* additive — `tokens(a + b) <= tokens(a)
+/// + tokens(b)` since adjacent pieces can merge into a single token
+/// across the boundary. Recomputing on the final buffer is the only
+/// way to get a count that matches what `tiktoken.cl100k_base.encode(
+/// full_output)` produces in Python.
 struct Budget<'a> {
     bpe: &'a CoreBPE,
     limit: usize,
+    body_limit: usize,
 }
 
 impl<'a> Budget<'a> {
     fn new(bpe: &'a CoreBPE, limit: usize) -> Self {
-        Self { bpe, limit }
+        // Worst-case footer width: digits scaled to 10x the limit so an
+        // overage report like `8500/800` still fits the reserve. The
+        // reserve is intentionally a couple tokens looser than strictly
+        // necessary; over-reserving costs at most a row of samples.
+        let max_used = limit.saturating_mul(10).max(limit);
+        let worst = format_footer(max_used, limit);
+        let footer_reserve = bpe.encode_ordinary(&worst).len();
+        let body_limit = limit.saturating_sub(footer_reserve);
+        Self { bpe, limit, body_limit }
     }
 
     /// Total tokens an accumulated buffer would cost (matches what
@@ -342,6 +406,27 @@ mod tests {
         let combined = b.used("hello world");
         let with = b.used_with("hello", " world");
         assert_eq!(combined, with);
+    }
+
+    #[test]
+    fn budget_reserves_room_for_footer() {
+        // body_limit must leave at least enough headroom that appending
+        // the actual footer never crosses `limit`. We use a worst-case
+        // reserve of 10x the limit's digit width as the numerator, so
+        // even when the orientation core overflows and the footer reads
+        // e.g. "8500/800", body_limit + footer fits the projection.
+        let bpe = cl100k_base_singleton();
+        let b = Budget::new(bpe, 800);
+        assert!(b.body_limit < b.limit, "must reserve nonzero footer space");
+        let realistic_footer = format_footer(b.limit, b.limit);
+        let footer_tokens = b.used(&realistic_footer);
+        assert!(
+            b.body_limit + footer_tokens <= b.limit,
+            "body_limit ({}) + realistic footer ({}) must fit limit ({})",
+            b.body_limit,
+            footer_tokens,
+            b.limit
+        );
     }
 
     #[test]

--- a/crates/wolfxl-cli/src/commands/mod.rs
+++ b/crates/wolfxl-cli/src/commands/mod.rs
@@ -1,2 +1,3 @@
+pub mod agent;
 pub mod map;
 pub mod peek;

--- a/crates/wolfxl-cli/src/main.rs
+++ b/crates/wolfxl-cli/src/main.rs
@@ -11,6 +11,7 @@ mod render;
 /// `wolfxl peek <file>` prints a styled, token-efficient view of a workbook —
 /// box / text / csv / json output, sheet selection, row and width caps.
 /// `wolfxl map <file>` prints a one-page summary of every sheet.
+/// `wolfxl agent <file> --max-tokens N` composes a token-budgeted briefing.
 #[derive(Parser, Debug)]
 #[command(name = "wolfxl", version, about, long_about = None)]
 struct Cli {
@@ -24,6 +25,8 @@ enum Command {
     Peek(PeekArgs),
     /// Print a one-page workbook overview (sheets, dims, headers, named ranges).
     Map(MapArgs),
+    /// Compose a token-budgeted workbook briefing for an LLM context window.
+    Agent(AgentArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -40,6 +43,20 @@ struct MapArgs {
 pub enum MapFormat {
     Json,
     Text,
+}
+
+#[derive(clap::Args, Debug)]
+struct AgentArgs {
+    /// Path to the workbook (.xlsx).
+    file: PathBuf,
+
+    /// Token budget (cl100k_base). Output is composed greedily to fit.
+    #[arg(short = 't', long = "max-tokens", default_value_t = 800)]
+    max_tokens: usize,
+
+    /// Sheet to focus on (default: largest data-class sheet, else first).
+    #[arg(short = 's', long)]
+    sheet: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -77,6 +94,7 @@ fn main() -> ExitCode {
     let result = match cli.command {
         Command::Peek(args) => commands::peek::run(args),
         Command::Map(args) => commands::map::run(args.file, args.format),
+        Command::Agent(args) => commands::agent::run(args.file, args.max_tokens, args.sheet),
     };
     match result {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/wolfxl-cli/tests/cli.rs
+++ b/crates/wolfxl-cli/tests/cli.rs
@@ -176,3 +176,65 @@ fn map_handles_wide_table_with_truncated_header_preview() {
     assert!(out.contains("[data] Dept Operations  (25 rows × 29 cols)"), "missing dims: {out}");
     assert!(out.contains("… (+21 more)"), "missing overflow marker: {out}");
 }
+
+#[test]
+fn agent_picks_largest_data_sheet_and_emits_overview_plus_samples() {
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&["agent", path.to_str().unwrap(), "--max-tokens", "800"]);
+    // Workbook overview lists every sheet with class + first column.
+    assert!(out.contains("WORKBOOK: sample-financials.xlsx"), "missing workbook line: {out}");
+    assert!(out.contains("- P&L (21r×7c) [data]"), "missing P&L overview: {out}");
+    assert!(out.contains("- Balance Sheet (27r×5c) [data]"), "missing balance sheet overview");
+    // Balance Sheet is the largest data sheet (27 > 21 > 13) so it's
+    // picked when --sheet isn't given.
+    assert!(
+        out.contains("SHEET: Balance Sheet  [data]  27 rows × 5 cols"),
+        "wrong target sheet: {out}"
+    );
+    assert!(out.contains("HEADERS: Account\tMar 31 2024"), "missing headers row: {out}");
+    // All three row sections fit at 800-token budget.
+    assert!(out.contains("ROWS (head 3 of"), "missing head block: {out}");
+    assert!(out.contains("ROWS (tail 2 of"), "missing tail block: {out}");
+    assert!(out.contains("ROWS (middle stratified"), "missing middle block: {out}");
+    // Footer reports cl100k_base accounting.
+    assert!(out.contains("# wolfxl agent:"), "missing footer: {out}");
+    assert!(out.contains("/800 tokens (cl100k_base)"), "wrong footer format: {out}");
+}
+
+#[test]
+fn agent_respects_explicit_sheet_override() {
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&["agent", path.to_str().unwrap(), "-s", "Revenue Breakdown"]);
+    assert!(
+        out.contains("SHEET: Revenue Breakdown"),
+        "explicit --sheet should win over largest-data heuristic: {out}"
+    );
+}
+
+#[test]
+fn agent_falls_back_to_orientation_when_budget_too_small() {
+    // 100-token budget can't fit the orientation core for a 3-sheet
+    // workbook with 5-7 column headers; we still emit it (overage
+    // reported in footer) and skip every row block. The agent at least
+    // learns the workbook structure.
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&["agent", path.to_str().unwrap(), "--max-tokens", "100"]);
+    assert!(out.contains("WORKBOOK:"), "must always emit workbook line");
+    assert!(out.contains("SHEET:"), "must always emit sheet header");
+    assert!(out.contains("HEADERS:"), "must always emit columns");
+    assert!(!out.contains("ROWS (head"), "head block must drop at tight budget: {out}");
+    assert!(!out.contains("ROWS (tail"), "tail block must drop at tight budget: {out}");
+}
+
+#[test]
+fn agent_unknown_sheet_errors() {
+    let path = fixture("sample-financials.xlsx");
+    let out = Command::cargo_bin("wolfxl")
+        .unwrap()
+        .args(["agent", path.to_str().unwrap(), "-s", "Does Not Exist"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("not found"), "stderr was: {stderr}");
+}


### PR DESCRIPTION
## Summary

Adds `wolfxl agent <file> --max-tokens N` — composes a token-budgeted workbook briefing sized to fit a target LLM context window. The orientation core (workbook overview + chosen sheet's headers) always lands; remaining budget greedily fills with stratified row samples.

This is sprint-1 step 8-9 (the second of the three T0 agent features). The first (`map`) shipped in #7 as 0.5.0; the third (`schema`) is queued as the next branch.

## Sample output (sample-financials.xlsx, --max-tokens 800)

```
WORKBOOK: sample-financials.xlsx
SHEETS:
  - P&L (21r×7c) [data] col1="Account"
  - Balance Sheet (27r×5c) [data] col1="Account"
  - Revenue Breakdown (13r×7c) [data] col1="Customer"

SHEET: Balance Sheet  [data]  27 rows × 5 cols
HEADERS: Account	Mar 31 2024	Dec 31 2023	Change $	Change %
ROWS (head 3 of 26):
  ASSETS
  Current Assets
    Cash & Equivalents	1842500	1120000	722500	64.5%
ROWS (tail 2 of 26):

  TOTAL LIABILITIES & EQUITY	2875500	2117000	758500	35.8%
ROWS (middle stratified, up to 8 of 21):
    Accounts Receivable	412800	385000	27800	7.2%
  Total Current Assets	2598500	1808500	790000	43.7%
  ...

# wolfxl agent: 306/800 tokens (cl100k_base)
```

## Composition order (greedy)

1. Workbook overview (every sheet, dims/class/first-column header)
2. Sheet header (largest data-class sheet, or `--sheet` override)
3. Column headers
4. Head 3 rows
5. Tail 2 rows
6. Stratified middle samples (uniform stride, up to 8)
7. Footer with token usage

## Token accounting

Counts come from `tiktoken-rs::cl100k_base` to match the GPT-4 family tokenizer used in `spreadsheet-peek/benchmarks/measure_tokens.py`. Verified end-to-end: Rust output reports 306 tokens; Python `tiktoken.cl100k_base.encode(out)` independently counts 306. Diff: **0 tokens** (spec was ±1).

`Budget::used_with(buf, section)` re-encodes the full concatenation rather than summing per-section counts, because cl100k_base BPE merges across boundaries — `tokens(a + b) <= tokens(a) + tokens(b)`. An additive check would over-count and reject sections that actually fit.

## Design notes worth surfacing for review

- **No thousand-grouping in agent mode.** Every comma is a token boundary in cl100k_base — `1234567` costs ~2 tokens, `1,234,567` costs ~5. Other renderers stay grouped (CSV/text/box are for humans); only `agent` rewrites.
- **Orientation core always lands**, even if it overflows. Better to report `# wolfxl agent: 114/100 tokens` than hide the workbook map.
- **Stratified middle, not just head.** An LLM seeing rows 1-3 of a 50-row P&L can't tell totals from line items. Head + tail + uniform-stride middle samples surface the shape.

## Test plan

- [x] `cargo test -p wolfxl-cli` — 10 unit tests + 18 integration tests, all green
  - 4 new unit tests covering: Budget non-additivity, sheet picker prefers largest Data, picker falls back to first when no Data, explicit `--sheet` overrides heuristic
  - 4 new integration tests covering: largest-data-sheet picker on real fixture, explicit `--sheet`, graceful tight-budget fallback, unknown-sheet error path
- [x] Smoke-tested at three budgets (100 / 400 / 800) on both fixtures
- [x] Manual Rust↔Python parity verification (306 = 306)
- [x] CHANGELOG entry under 0.6.0
- [x] Cargo.toml description refreshed to surface all three subcommands

## Deferred

- `--schema` per-column type inference (next branch, sprint step 10)
- Schema one-liner in agent output (depends on `--schema` work landing)
- Configurable head/tail counts (defaults of 3/2 are fine for V1)

## Version bump

0.5.0 → **0.6.0** (minor; new public CLI subcommand, no breaking changes to `peek` or `map`).

## Deps

Adds `tiktoken-rs 0.11` (7 transitive: bit-set, bit-vec, fancy-regex, lazy_static, rustc-hash, base64, plus tiktoken-rs itself). The BPE table is bundled in the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)