### PR TITLE
feat(cli): add `wolfxl schema` subcommand for per-column inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,44 @@
 # Changelog
 
-## 0.6.0 (2026-04-19)
+## wolfxl-cli 0.7.0 / wolfxl-core 0.6.0 (2026-04-19)
+
+### Added
+
+- **`wolfxl schema <file>` subcommand**: per-column type, cardinality,
+  null count, format category, and up to three sample values. Defaults
+  to JSON for agent consumption; `--format text` produces a tabular
+  terminal view. Pass `--sheet NAME` to scope to one sheet, omit to
+  schema every sheet in the workbook.
+- **`wolfxl-core::schema` module**: `InferredType`, `Cardinality`,
+  `ColumnSchema`, `SheetSchema`, and the `infer_sheet_schema` entry
+  point — callable from third-party Rust consumers, identical answers
+  to the CLI.
+
+### Notes
+
+- **Cardinality buckets** are: `unique` (every non-null cell distinct),
+  `categorical` (≤20 distinct AND distinct × 2 ≤ non-null — the
+  "lookup-friendly dimension" bucket an agent needs to plan a `WHERE`
+  clause), `high-cardinality` (everything else above the cap or with
+  many distincts), and `empty`.
+- **Type inference** collapses `Int + Float` in the same column to
+  `Float` (numeric supertype). Any other multi-type column resolves to
+  `Mixed` so an agent doesn't pick a dominant type from a noisy mix.
+- **Unique-count tracking is capped at 10 000** distinct rendered
+  values per column; columns past the cap report
+  `unique_capped: true` and class as `high-cardinality` (the safer
+  bucket — caller won't wrongly treat an unverified column as a
+  categorical lookup). Picked so a million-row sheet doesn't blow
+  memory on the per-column HashSet.
+- **Format category is locked from the first non-empty cell** of each
+  column. Mixed-format columns are rare in practice; if a user wanted
+  per-cell formatting they would be looking at a CSV. Note: openpyxl-
+  generated fixtures often emit no `cellXfs` styles, so format
+  detection on those workbooks falls back to `general`. Real Excel-
+  authored workbooks carry the styles correctly. The full styles.xml
+  walker that lifts this limitation is tracked separately.
+
+## wolfxl-cli 0.6.0 (2026-04-19)
 
 ### Added
 
@@ -22,7 +60,12 @@
 - **Token budget tracker**: `Budget::used_with(buf, section)` re-encodes
   the full concatenation rather than summing per-section counts, because
   cl100k_base BPE merges across boundaries (additive checks would
-  over-count and reject sections that actually fit).
+  over-count and reject sections that actually fit). After PR review,
+  the budget reserves a worst-case footer cost up-front so the printed
+  `--max-tokens N` is honored end-to-end (body + footer).
+- Best-effort `NAMED_RANGES` block (capped at 8 entries with overflow
+  marker) gated through `try_append`, so a workbook with hundreds of
+  named ranges cannot single-handedly drain the agent's budget.
 
 ### Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "wolfxl-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "wolfxl-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "calamine-styles",
  "chrono",

--- a/crates/wolfxl-cli/Cargo.toml
+++ b/crates/wolfxl-cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wolfxl-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Excel xlsx previewer for AI agents. Installs the `wolfxl` binary with `peek` (styled previews), `map` (workbook overview), and `agent` (token-budgeted briefing) subcommands."
+description = "Excel xlsx previewer for AI agents. Installs the `wolfxl` binary with `peek` (styled previews), `map` (workbook overview), `agent` (token-budgeted briefing), and `schema` (per-column type/cardinality/format inference) subcommands."
 readme = "README.md"
 keywords = ["xlsx", "excel", "cli", "preview", "spreadsheet"]
 categories = ["command-line-utilities", "visualization"]
@@ -14,7 +14,7 @@ name = "wolfxl"
 path = "src/main.rs"
 
 [dependencies]
-wolfxl-core = { path = "../wolfxl-core", version = "0.5.0" }
+wolfxl-core = { path = "../wolfxl-core", version = "0.6.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 serde_json.workspace = true

--- a/crates/wolfxl-cli/src/commands/mod.rs
+++ b/crates/wolfxl-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod agent;
 pub mod map;
 pub mod peek;
+pub mod schema;

--- a/crates/wolfxl-cli/src/commands/schema.rs
+++ b/crates/wolfxl-cli/src/commands/schema.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use serde_json::{Value, json};
+use unicode_width::UnicodeWidthStr;
 use wolfxl_core::{SheetSchema, Workbook, infer_sheet_schema};
 
 use crate::SchemaFormat;
@@ -106,10 +107,25 @@ fn print_text(schemas: &[SheetSchema]) {
     }
 }
 
+/// Truncate `s` so its terminal display width fits in `max` columns,
+/// appending `…` (1-wide) when truncation happens. Uses unicode-width to
+/// match the column-alignment behavior of `wolfxl peek`'s boxed renderer
+/// — `chars().count()` would misalign on CJK / wide glyphs.
 fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
+    if s.width() <= max {
         return s.to_string();
     }
-    let head: String = s.chars().take(max.saturating_sub(1)).collect();
-    format!("{head}…")
+    let budget = max.saturating_sub(1); // reserve 1 column for the ellipsis
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in s.chars() {
+        let w = ch.to_string().width();
+        if used + w > budget {
+            break;
+        }
+        out.push(ch);
+        used += w;
+    }
+    out.push('…');
+    out
 }

--- a/crates/wolfxl-cli/src/commands/schema.rs
+++ b/crates/wolfxl-cli/src/commands/schema.rs
@@ -1,0 +1,115 @@
+//! `wolfxl schema <file>` — per-column type/cardinality/format inference.
+//!
+//! Defaults to JSON for agent consumption; `--format text` produces a
+//! terminal-friendly tabular view. Omit `--sheet` to schema every sheet
+//! in the workbook; pass it to scope to one sheet.
+//!
+//! The heuristics live in `wolfxl_core::schema` so third-party Rust
+//! callers (and the future Python binding) get the same answers as the
+//! CLI; this module is pure rendering.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use wolfxl_core::{SheetSchema, Workbook, infer_sheet_schema};
+
+use crate::SchemaFormat;
+
+pub fn run(file: PathBuf, format: SchemaFormat, sheet: Option<String>) -> Result<()> {
+    let mut wb = Workbook::open(&file)
+        .with_context(|| format!("opening workbook {}", file.display()))?;
+
+    let sheet_names: Vec<String> = wb.sheet_names().to_vec();
+    let targets: Vec<String> = match sheet {
+        Some(name) => {
+            if !sheet_names.iter().any(|n| n == &name) {
+                anyhow::bail!(
+                    "sheet {name:?} not found; available: {}",
+                    sheet_names.join(", ")
+                );
+            }
+            vec![name]
+        }
+        None => sheet_names.clone(),
+    };
+
+    let mut schemas: Vec<SheetSchema> = Vec::with_capacity(targets.len());
+    for name in &targets {
+        let s = wb
+            .sheet(name)
+            .with_context(|| format!("loading sheet {name:?}"))?;
+        schemas.push(infer_sheet_schema(&s));
+    }
+
+    match format {
+        SchemaFormat::Json => print_json(&file, &schemas)?,
+        SchemaFormat::Text => print_text(&schemas),
+    }
+    Ok(())
+}
+
+fn print_json(file: &std::path::Path, schemas: &[SheetSchema]) -> Result<()> {
+    let value = json!({
+        "path": file.to_string_lossy(),
+        "sheets": schemas.iter().map(sheet_to_json).collect::<Vec<Value>>(),
+    });
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}
+
+fn sheet_to_json(s: &SheetSchema) -> Value {
+    json!({
+        "name": s.sheet,
+        "rows": s.rows,
+        "columns": s.columns.iter().map(|c| json!({
+            "name": c.name,
+            "type": c.inferred_type.as_str(),
+            "format": c.format_category.as_str(),
+            "null_count": c.null_count,
+            "unique_count": c.unique_count,
+            "unique_capped": c.unique_capped,
+            "cardinality": c.cardinality.as_str(),
+            "samples": c.sample_values,
+        })).collect::<Vec<Value>>(),
+    })
+}
+
+fn print_text(schemas: &[SheetSchema]) {
+    for (i, s) in schemas.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        println!("Sheet: {}  ({} rows)", s.sheet, s.rows);
+        println!("{:<24} {:<9} {:<11} {:<7} {:<7} {:<16} samples", "column", "type", "format", "nulls", "unique", "cardinality");
+        println!("{}", "-".repeat(96));
+        for c in &s.columns {
+            let unique = if c.unique_capped {
+                format!("{}+", c.unique_count)
+            } else {
+                c.unique_count.to_string()
+            };
+            // Rendered samples can contain commas — join with `|` so a
+            // copy-paste back into the shell or a CSV stays unambiguous.
+            let samples = c.sample_values.join(" | ");
+            println!(
+                "{:<24} {:<9} {:<11} {:<7} {:<7} {:<16} {}",
+                truncate(&c.name, 24),
+                c.inferred_type.as_str(),
+                c.format_category.as_str(),
+                c.null_count,
+                unique,
+                c.cardinality.as_str(),
+                truncate(&samples, 40),
+            );
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{head}…")
+}

--- a/crates/wolfxl-cli/src/main.rs
+++ b/crates/wolfxl-cli/src/main.rs
@@ -12,6 +12,7 @@ mod render;
 /// box / text / csv / json output, sheet selection, row and width caps.
 /// `wolfxl map <file>` prints a one-page summary of every sheet.
 /// `wolfxl agent <file> --max-tokens N` composes a token-budgeted briefing.
+/// `wolfxl schema <file>` emits per-column type, cardinality, and format.
 #[derive(Parser, Debug)]
 #[command(name = "wolfxl", version, about, long_about = None)]
 struct Cli {
@@ -27,6 +28,8 @@ enum Command {
     Map(MapArgs),
     /// Compose a token-budgeted workbook briefing for an LLM context window.
     Agent(AgentArgs),
+    /// Per-column schema: type, cardinality, null count, format category.
+    Schema(SchemaArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -57,6 +60,26 @@ struct AgentArgs {
     /// Sheet to focus on (default: largest data-class sheet, else first).
     #[arg(short = 's', long)]
     sheet: Option<String>,
+}
+
+#[derive(clap::Args, Debug)]
+struct SchemaArgs {
+    /// Path to the workbook (.xlsx).
+    file: PathBuf,
+
+    /// Sheet name. Omit to schema every sheet in the workbook.
+    #[arg(short = 's', long)]
+    sheet: Option<String>,
+
+    /// Output format.
+    #[arg(short = 'f', long = "format", default_value = "json")]
+    format: SchemaFormat,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum SchemaFormat {
+    Json,
+    Text,
 }
 
 #[derive(clap::Args, Debug)]
@@ -95,6 +118,7 @@ fn main() -> ExitCode {
         Command::Peek(args) => commands::peek::run(args),
         Command::Map(args) => commands::map::run(args.file, args.format),
         Command::Agent(args) => commands::agent::run(args.file, args.max_tokens, args.sheet),
+        Command::Schema(args) => commands::schema::run(args.file, args.format, args.sheet),
     };
     match result {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/wolfxl-cli/tests/cli.rs
+++ b/crates/wolfxl-cli/tests/cli.rs
@@ -238,3 +238,65 @@ fn agent_unknown_sheet_errors() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("not found"), "stderr was: {stderr}");
 }
+
+#[test]
+fn schema_default_emits_all_sheets_as_json() {
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&["schema", path.to_str().unwrap()]);
+    let v: serde_json::Value = serde_json::from_str(&out).expect("schema JSON parses");
+    let sheets = v["sheets"].as_array().expect("sheets is array");
+    assert_eq!(sheets.len(), 3, "default scopes to all sheets");
+    let names: Vec<&str> = sheets.iter().map(|s| s["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"P&L"));
+    assert!(names.contains(&"Balance Sheet"));
+    assert!(names.contains(&"Revenue Breakdown"));
+}
+
+#[test]
+fn schema_revenue_breakdown_classifies_segment_as_categorical() {
+    // The Segment column has 4 distinct values across the body rows
+    // (Enterprise / Mid-Market / SMB / one more). With unique * 2 ≤ non_null
+    // and unique ≤ 20 it should be classed as `categorical` — the bucket
+    // an agent uses to recognize lookup-friendly dimensions.
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&["schema", path.to_str().unwrap(), "--sheet", "Revenue Breakdown"]);
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    let cols = v["sheets"][0]["columns"].as_array().unwrap();
+    let segment = cols
+        .iter()
+        .find(|c| c["name"] == "Segment")
+        .expect("Segment column present");
+    assert_eq!(segment["type"], "string");
+    assert_eq!(segment["cardinality"], "categorical");
+    let samples = segment["samples"].as_array().unwrap();
+    assert!(samples.len() <= 3, "samples capped at 3");
+}
+
+#[test]
+fn schema_text_format_renders_table_with_header() {
+    let path = fixture("sample-financials.xlsx");
+    let out = run(&[
+        "schema",
+        path.to_str().unwrap(),
+        "--sheet",
+        "Revenue Breakdown",
+        "--format",
+        "text",
+    ]);
+    assert!(out.contains("Sheet: Revenue Breakdown"), "missing sheet header: {out}");
+    assert!(out.contains("column") && out.contains("type") && out.contains("cardinality"));
+    assert!(out.contains("Customer"), "missing column row: {out}");
+}
+
+#[test]
+fn schema_unknown_sheet_errors() {
+    let path = fixture("sample-financials.xlsx");
+    let out = Command::cargo_bin("wolfxl")
+        .unwrap()
+        .args(["schema", path.to_str().unwrap(), "--sheet", "Nope"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("not found"), "stderr: {stderr}");
+}

--- a/crates/wolfxl-core/Cargo.toml
+++ b/crates/wolfxl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfxl-core"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/wolfxl-core/src/lib.rs
+++ b/crates/wolfxl-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod cell;
 pub mod error;
 pub mod format;
 pub mod map;
+pub mod schema;
 pub mod sheet;
 pub mod workbook;
 
@@ -36,5 +37,6 @@ pub use cell::{Cell, CellValue};
 pub use error::{Error, Result};
 pub use format::{FormatCategory, format_cell};
 pub use map::{SheetClass, SheetMap, WorkbookMap, classify_sheet};
+pub use schema::{Cardinality, ColumnSchema, InferredType, SheetSchema, infer_sheet_schema};
 pub use sheet::Sheet;
 pub use workbook::Workbook;

--- a/crates/wolfxl-core/src/schema.rs
+++ b/crates/wolfxl-core/src/schema.rs
@@ -1,0 +1,444 @@
+//! Per-column schema inference: type, null count, cardinality, format.
+//!
+//! Built for the `wolfxl schema` agent subcommand. Returns enough per-column
+//! detail for an LLM to plan a query strategy without round-tripping the
+//! actual data: pick lookup columns by `cardinality`, choose dimension vs
+//! measure by `inferred_type` + `format_category`, decide whether `unique_count`
+//! is exact or capped before treating it as a primary key.
+//!
+//! All inference is single-pass O(rows × cols). Unique-count tracking caps
+//! at 10 000 distinct rendered values per column so a million-row sheet
+//! doesn't blow memory; the cap is reported via `unique_capped`.
+
+use std::collections::HashSet;
+
+use crate::cell::{Cell, CellValue};
+use crate::format::{classify_format, FormatCategory};
+use crate::sheet::Sheet;
+
+/// Inferred logical type for a column. `Mixed` means "no clear majority";
+/// `Empty` means "no non-null cells were observed".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InferredType {
+    String,
+    Int,
+    Float,
+    Bool,
+    Date,
+    DateTime,
+    Time,
+    Mixed,
+    Empty,
+}
+
+impl InferredType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            InferredType::String => "string",
+            InferredType::Int => "int",
+            InferredType::Float => "float",
+            InferredType::Bool => "bool",
+            InferredType::Date => "date",
+            InferredType::DateTime => "datetime",
+            InferredType::Time => "time",
+            InferredType::Mixed => "mixed",
+            InferredType::Empty => "empty",
+        }
+    }
+}
+
+/// Coarse cardinality bucket — what an agent needs to decide "is this a
+/// dimension or a measure?".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cardinality {
+    /// Every non-null value is distinct.
+    Unique,
+    /// Few distinct values (≤20) and at most half of rows. Lookup-friendly.
+    Categorical,
+    /// Many distinct values, not unique. Typical for measures, IDs, names.
+    HighCardinality,
+    /// Column has no non-null cells.
+    Empty,
+}
+
+impl Cardinality {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Cardinality::Unique => "unique",
+            Cardinality::Categorical => "categorical",
+            Cardinality::HighCardinality => "high-cardinality",
+            Cardinality::Empty => "empty",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ColumnSchema {
+    pub name: String,
+    pub inferred_type: InferredType,
+    /// First-non-empty-cell number-format category. Drives whether the
+    /// column is "dollars" vs "percent" vs "plain integer" — orthogonal to
+    /// `inferred_type` (a `currency` column is still typed `Float`).
+    pub format_category: FormatCategory,
+    pub null_count: usize,
+    /// Distinct rendered-value count, capped at 10 000.
+    pub unique_count: usize,
+    pub unique_capped: bool,
+    pub cardinality: Cardinality,
+    /// Up to 3 distinct rendered values. Order is whatever the column
+    /// presented first; not stable across runs if the underlying sheet
+    /// changes. Useful for grounding agent queries with concrete values.
+    pub sample_values: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SheetSchema {
+    pub sheet: String,
+    pub rows: usize,
+    pub columns: Vec<ColumnSchema>,
+}
+
+/// Hard cap on the per-column unique-value HashSet to keep a million-row
+/// sheet from blowing memory. 10 000 is enough to confidently call a
+/// column "high-cardinality" without exact counts past that point.
+pub const UNIQUE_CAP: usize = 10_000;
+
+const SAMPLE_LIMIT: usize = 3;
+/// Categorical bucket upper bound on distinct values. Above this, a column
+/// is too varied to be useful as a lookup dimension even if it's still
+/// dense.
+const CATEGORICAL_MAX_DISTINCT: usize = 20;
+
+/// Infer per-column schema for a sheet. Header is row 0; body starts at
+/// row 1. Returns one [`ColumnSchema`] per column reported by `headers()`.
+pub fn infer_sheet_schema(sheet: &Sheet) -> SheetSchema {
+    let headers = sheet.headers();
+    let (total_rows, _) = sheet.dimensions();
+    let body_rows = total_rows.saturating_sub(1);
+    let cols = headers.len();
+    let mut columns = Vec::with_capacity(cols);
+
+    for col_idx in 0..cols {
+        columns.push(infer_column(sheet, col_idx, &headers[col_idx], body_rows));
+    }
+
+    SheetSchema {
+        sheet: sheet.name.clone(),
+        rows: body_rows,
+        columns,
+    }
+}
+
+fn infer_column(sheet: &Sheet, col_idx: usize, name: &str, body_rows: usize) -> ColumnSchema {
+    let mut counts = TypeCounts::default();
+    let mut null_count = 0usize;
+    let mut uniques: HashSet<String> = HashSet::new();
+    let mut unique_capped = false;
+    let mut samples: Vec<String> = Vec::with_capacity(SAMPLE_LIMIT);
+    let mut format_category = FormatCategory::General;
+    let mut format_locked = false;
+
+    for row in sheet.rows().iter().skip(1) {
+        let cell = match row.get(col_idx) {
+            Some(c) => c,
+            None => {
+                null_count += 1;
+                continue;
+            }
+        };
+
+        if matches!(cell.value, CellValue::Empty) {
+            null_count += 1;
+            continue;
+        }
+
+        // Lock the format from the first non-empty cell. Mixed-format
+        // columns are rare in practice; if the user wanted that, they'd
+        // be looking at a CSV not an xlsx.
+        if !format_locked {
+            if let Some(fmt) = &cell.number_format {
+                format_category = classify_format(fmt);
+            }
+            format_locked = true;
+        }
+
+        counts.observe(&cell.value);
+
+        let rendered = render_for_uniqueness(cell);
+        if !unique_capped {
+            if uniques.len() < UNIQUE_CAP {
+                if uniques.insert(rendered.clone()) && samples.len() < SAMPLE_LIMIT {
+                    samples.push(rendered);
+                }
+            } else {
+                unique_capped = true;
+            }
+        }
+    }
+
+    let inferred_type = counts.dominant();
+    let unique_count = uniques.len();
+    let non_null = body_rows.saturating_sub(null_count);
+    let cardinality = classify_cardinality(unique_count, non_null, unique_capped);
+
+    ColumnSchema {
+        name: name.to_string(),
+        inferred_type,
+        format_category,
+        null_count,
+        unique_count,
+        unique_capped,
+        cardinality,
+        sample_values: samples,
+    }
+}
+
+/// Render a cell's value for distinct-set membership. Same semantics as
+/// what an agent would see in `wolfxl peek -e text` for that cell, minus
+/// thousand grouping (so `1000` and `1,000` aren't counted twice — but the
+/// underlying value space is the same).
+fn render_for_uniqueness(cell: &Cell) -> String {
+    match &cell.value {
+        CellValue::Empty => String::new(),
+        CellValue::String(s) => s.clone(),
+        CellValue::Bool(b) => b.to_string(),
+        CellValue::Int(n) => n.to_string(),
+        CellValue::Float(n) => format!("{n}"),
+        CellValue::Date(d) => d.format("%Y-%m-%d").to_string(),
+        CellValue::DateTime(dt) => dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
+        CellValue::Time(t) => t.format("%H:%M:%S").to_string(),
+        CellValue::Error(e) => format!("ERR:{e}"),
+    }
+}
+
+fn classify_cardinality(unique: usize, non_null: usize, capped: bool) -> Cardinality {
+    if non_null == 0 {
+        return Cardinality::Empty;
+    }
+    // If the unique tracker hit its cap we cannot prove uniqueness either
+    // way, so default to high-cardinality (the safer bucket — caller won't
+    // wrongly treat it as a categorical lookup).
+    if capped {
+        return Cardinality::HighCardinality;
+    }
+    if unique == non_null {
+        return Cardinality::Unique;
+    }
+    if unique <= CATEGORICAL_MAX_DISTINCT && unique * 2 <= non_null {
+        return Cardinality::Categorical;
+    }
+    Cardinality::HighCardinality
+}
+
+#[derive(Default)]
+struct TypeCounts {
+    string: usize,
+    int: usize,
+    float: usize,
+    bool_: usize,
+    date: usize,
+    datetime: usize,
+    time: usize,
+    error: usize,
+}
+
+impl TypeCounts {
+    fn observe(&mut self, v: &CellValue) {
+        match v {
+            CellValue::Empty => {}
+            CellValue::String(_) => self.string += 1,
+            CellValue::Int(_) => self.int += 1,
+            CellValue::Float(_) => self.float += 1,
+            CellValue::Bool(_) => self.bool_ += 1,
+            CellValue::Date(_) => self.date += 1,
+            CellValue::DateTime(_) => self.datetime += 1,
+            CellValue::Time(_) => self.time += 1,
+            CellValue::Error(_) => self.error += 1,
+        }
+    }
+
+    /// Pick the dominant type. Int + Float coexisting in the same column
+    /// resolve to Float (numeric supertype). Anything else with two or
+    /// more types contributing returns Mixed.
+    fn dominant(&self) -> InferredType {
+        let total =
+            self.string + self.int + self.float + self.bool_ + self.date + self.datetime + self.time + self.error;
+        if total == 0 {
+            return InferredType::Empty;
+        }
+        // Int+Float merge: if numeric is the only category present, return
+        // Float when any cell was Float, else Int.
+        let numeric = self.int + self.float;
+        if numeric == total {
+            return if self.float > 0 {
+                InferredType::Float
+            } else {
+                InferredType::Int
+            };
+        }
+
+        let pairs: [(usize, InferredType); 7] = [
+            (self.string, InferredType::String),
+            (self.bool_, InferredType::Bool),
+            (self.date, InferredType::Date),
+            (self.datetime, InferredType::DateTime),
+            (self.time, InferredType::Time),
+            // Numeric collapses to a single bucket so a column of 9 floats
+            // and 1 string still resolves to Mixed (not Float-wins-because-
+            // it's-the-largest); but a column that's pure numeric was
+            // already handled above.
+            (numeric, InferredType::Float),
+            (self.error, InferredType::String),
+        ];
+        let nonzero = pairs.iter().filter(|(c, _)| *c > 0).count();
+        if nonzero > 1 {
+            return InferredType::Mixed;
+        }
+        pairs.iter().find(|(c, _)| *c > 0).map(|(_, t)| *t).unwrap_or(InferredType::Empty)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &str) -> Cell {
+        Cell { value: CellValue::String(v.to_string()), number_format: None }
+    }
+    fn i(n: i64) -> Cell {
+        Cell { value: CellValue::Int(n), number_format: None }
+    }
+    fn f(n: f64) -> Cell {
+        Cell { value: CellValue::Float(n), number_format: None }
+    }
+    fn empty() -> Cell {
+        Cell::empty()
+    }
+    fn currency_f(n: f64) -> Cell {
+        Cell {
+            value: CellValue::Float(n),
+            number_format: Some("$#,##0.00".to_string()),
+        }
+    }
+
+    fn sheet_with(name: &str, rows: Vec<Vec<Cell>>) -> Sheet {
+        Sheet::from_rows_for_test(name, rows)
+    }
+
+    #[test]
+    fn pure_int_column_infers_int_unique_when_distinct() {
+        let rows = vec![
+            vec![s("id")],
+            vec![i(1)],
+            vec![i(2)],
+            vec![i(3)],
+        ];
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let col = &schema.columns[0];
+        assert_eq!(col.inferred_type, InferredType::Int);
+        assert_eq!(col.null_count, 0);
+        assert_eq!(col.unique_count, 3);
+        assert_eq!(col.cardinality, Cardinality::Unique);
+    }
+
+    #[test]
+    fn int_plus_float_collapses_to_float() {
+        let rows = vec![
+            vec![s("price")],
+            vec![i(1)],
+            vec![f(2.5)],
+            vec![i(3)],
+        ];
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        assert_eq!(schema.columns[0].inferred_type, InferredType::Float);
+    }
+
+    #[test]
+    fn mixed_string_and_numeric_returns_mixed() {
+        let rows = vec![
+            vec![s("col")],
+            vec![s("hello")],
+            vec![i(42)],
+        ];
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        assert_eq!(schema.columns[0].inferred_type, InferredType::Mixed);
+    }
+
+    #[test]
+    fn categorical_bucket_when_few_repeated_values() {
+        // 12 rows, 3 distinct values, all repeated → categorical.
+        let rows = vec![
+            vec![s("region")],
+            vec![s("us")],
+            vec![s("eu")],
+            vec![s("apac")],
+            vec![s("us")],
+            vec![s("eu")],
+            vec![s("apac")],
+            vec![s("us")],
+            vec![s("eu")],
+            vec![s("apac")],
+            vec![s("us")],
+            vec![s("eu")],
+            vec![s("apac")],
+        ];
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let col = &schema.columns[0];
+        assert_eq!(col.unique_count, 3);
+        assert_eq!(col.cardinality, Cardinality::Categorical);
+        assert_eq!(col.sample_values.len(), 3);
+    }
+
+    #[test]
+    fn high_cardinality_when_distinct_count_too_high_for_categorical() {
+        // 21 distinct values exceeds CATEGORICAL_MAX_DISTINCT (20), so
+        // even though every value repeats once it still classes as
+        // high-cardinality.
+        let rows: Vec<Vec<Cell>> = std::iter::once(vec![s("x")])
+            .chain((0..21).map(|i| vec![s(&format!("v{i}"))]))
+            .chain((0..21).map(|i| vec![s(&format!("v{i}"))]))
+            .collect();
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let col = &schema.columns[0];
+        assert_eq!(col.unique_count, 21);
+        assert_eq!(col.cardinality, Cardinality::HighCardinality);
+    }
+
+    #[test]
+    fn null_count_handles_short_rows_and_empty_cells() {
+        let rows = vec![
+            vec![s("a"), s("b")],
+            vec![i(1), empty()],
+            vec![i(2)], // short row - col 1 is missing
+            vec![i(3), i(4)],
+        ];
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let b = &schema.columns[1];
+        assert_eq!(b.null_count, 2);
+        assert_eq!(b.unique_count, 1);
+    }
+
+    #[test]
+    fn currency_format_locked_from_first_non_empty_cell() {
+        let rows = vec![
+            vec![s("revenue")],
+            vec![empty()],
+            vec![currency_f(1500.0)],
+            vec![currency_f(2500.0)],
+        ];
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let col = &schema.columns[0];
+        assert_eq!(col.format_category, FormatCategory::Currency);
+        assert_eq!(col.inferred_type, InferredType::Float);
+    }
+
+    #[test]
+    fn empty_column_classifies_as_empty() {
+        let rows = vec![vec![s("a")], vec![empty()], vec![empty()]];
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let col = &schema.columns[0];
+        assert_eq!(col.inferred_type, InferredType::Empty);
+        assert_eq!(col.cardinality, Cardinality::Empty);
+        assert_eq!(col.null_count, 2);
+    }
+}

--- a/crates/wolfxl-core/src/schema.rs
+++ b/crates/wolfxl-core/src/schema.rs
@@ -1,7 +1,7 @@
 //! Per-column schema inference: type, null count, cardinality, format.
 //!
-//! Built for the `wolfxl schema` agent subcommand. Returns enough per-column
-//! detail for an LLM to plan a query strategy without round-tripping the
+//! Built for the `wolfxl schema` subcommand. Returns enough per-column detail
+//! for an LLM or agent to plan a query strategy without round-tripping the
 //! actual data: pick lookup columns by `cardinality`, choose dimension vs
 //! measure by `inferred_type` + `format_category`, decide whether `unique_count`
 //! is exact or capped before treating it as a primary key.
@@ -166,11 +166,19 @@ fn infer_column(sheet: &Sheet, col_idx: usize, name: &str, body_rows: usize) -> 
 
         let rendered = render_for_uniqueness(cell);
         if !unique_capped {
-            if uniques.len() < UNIQUE_CAP {
-                if uniques.insert(rendered.clone()) && samples.len() < SAMPLE_LIMIT {
+            if uniques.contains(&rendered) {
+                // Already-seen value: no cap consideration, no sample
+                // update needed.
+            } else if uniques.len() < UNIQUE_CAP {
+                uniques.insert(rendered.clone());
+                if samples.len() < SAMPLE_LIMIT {
                     samples.push(rendered);
                 }
             } else {
+                // First *new* distinct value past the cap. A column with
+                // exactly UNIQUE_CAP distinct values followed by repeats
+                // stays uncapped — `unique_count == UNIQUE_CAP` is then an
+                // exact, trustworthy figure.
                 unique_capped = true;
             }
         }
@@ -193,10 +201,18 @@ fn infer_column(sheet: &Sheet, col_idx: usize, name: &str, body_rows: usize) -> 
     }
 }
 
-/// Render a cell's value for distinct-set membership. Same semantics as
-/// what an agent would see in `wolfxl peek -e text` for that cell, minus
-/// thousand grouping (so `1000` and `1,000` aren't counted twice — but the
-/// underlying value space is the same).
+/// Render a cell's value as a HashSet key for distinct-counting and as a
+/// human-readable sample. Date/time/error formats follow the same conventions
+/// as `wolfxl peek -e text` (space-separated DateTime, `ERROR: ` error
+/// prefix) so a sample dropped into a `peek` filter expression matches what
+/// an agent would otherwise see.
+///
+/// Two intentional divergences from peek's text renderer:
+/// - **Floats keep full Rust precision** (`format!("{n}")`) rather than
+///   rounding to two decimals: dedup correctness needs `1.234` and `1.236`
+///   to count as distinct.
+/// - **Ints are not thousand-grouped**: `1000` and `1,000` would otherwise
+///   key into the HashSet as different strings.
 fn render_for_uniqueness(cell: &Cell) -> String {
     match &cell.value {
         CellValue::Empty => String::new(),
@@ -205,9 +221,9 @@ fn render_for_uniqueness(cell: &Cell) -> String {
         CellValue::Int(n) => n.to_string(),
         CellValue::Float(n) => format!("{n}"),
         CellValue::Date(d) => d.format("%Y-%m-%d").to_string(),
-        CellValue::DateTime(dt) => dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
+        CellValue::DateTime(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
         CellValue::Time(t) => t.format("%H:%M:%S").to_string(),
-        CellValue::Error(e) => format!("ERR:{e}"),
+        CellValue::Error(e) => format!("ERROR: {e}"),
     }
 }
 
@@ -430,6 +446,43 @@ mod tests {
         let col = &schema.columns[0];
         assert_eq!(col.format_category, FormatCategory::Currency);
         assert_eq!(col.inferred_type, InferredType::Float);
+    }
+
+    #[test]
+    fn at_cap_then_repeats_stays_uncapped() {
+        // A column with exactly UNIQUE_CAP distinct values followed by a
+        // long run of repeats should report the exact count and stay
+        // uncapped. The earlier flip-on-next-row logic incorrectly set
+        // `unique_capped: true` (and forced HighCardinality) on the first
+        // duplicate after the cap, misleading downstream callers about
+        // whether the cardinality figure was trustworthy.
+        let mut rows: Vec<Vec<Cell>> = vec![vec![s("id")]];
+        for n in 0..(UNIQUE_CAP as i64) {
+            rows.push(vec![i(n)]);
+        }
+        // Repeats — these must NOT flip `unique_capped`.
+        for n in 0..50 {
+            rows.push(vec![i(n)]);
+        }
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let col = &schema.columns[0];
+        assert_eq!(col.unique_count, UNIQUE_CAP);
+        assert!(!col.unique_capped, "exact-at-cap with only repeats should stay uncapped");
+    }
+
+    #[test]
+    fn one_past_cap_flips_capped() {
+        // The first genuinely new value beyond UNIQUE_CAP correctly flips
+        // the capped flag; subsequent classification falls back to
+        // HighCardinality (the safer bucket).
+        let mut rows: Vec<Vec<Cell>> = vec![vec![s("id")]];
+        for n in 0..((UNIQUE_CAP + 1) as i64) {
+            rows.push(vec![i(n)]);
+        }
+        let schema = infer_sheet_schema(&sheet_with("t", rows));
+        let col = &schema.columns[0];
+        assert!(col.unique_capped);
+        assert_eq!(col.cardinality, Cardinality::HighCardinality);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- New **`wolfxl schema <file>`** subcommand: per-column type, cardinality, null count, format category, and up to 3 sample values. Defaults to JSON; `--format text` for terminal. Optional `--sheet NAME` to scope to one sheet; omit to schema every sheet.
- New public **`wolfxl-core::schema`** module (`InferredType`, `Cardinality`, `ColumnSchema`, `SheetSchema`, `infer_sheet_schema`) so third-party Rust callers get the same answers as the CLI.
- Bumps **`wolfxl-core` 0.5.0 → 0.6.0** (new public API surface) and **`wolfxl-cli` 0.5.0 → 0.7.0** (skipping 0.6.0 reserved for the in-flight #8 agent PR — rebase after that lands).

## Heuristic decisions worth flagging

- **Cardinality buckets**: `unique` / `categorical` (≤20 distinct AND distinct × 2 ≤ non-null) / `high-cardinality` / `empty`. The `× 2` factor was tuned against `Revenue Breakdown.Segment` (4 distinct in 10 non-null) — looser thresholds wrongly classed it as high-cardinality and made the bucket useless on small sheets.
- **Type inference**: `Int + Float` in the same column collapses to `Float` (numeric supertype). Anything else multi-type → `Mixed` so an agent doesn't pick a dominant type from a noisy mix.
- **Unique tracking caps at 10 000** distinct rendered values per column → `unique_capped: true`, classed as `high-cardinality` (the safer bucket — caller won't wrongly treat an unverified column as a categorical lookup).
- **Format category locked from the first non-empty cell**. openpyxl-generated fixtures often emit no `cellXfs`, so format detection on those workbooks falls back to `general`. The full styles.xml walker that lifts this is tracked separately.

## Test plan

- [x] `cargo test -p wolfxl-core schema` — 8 new unit tests pass (pure-int unique, int+float→float collapse, mixed→Mixed, categorical bucket, high-cardinality threshold, null/short rows, currency-format lock, empty-column).
- [x] `cargo test -p wolfxl-cli --test cli` — 18 integration tests (4 new schema tests + 14 existing) pass.
- [x] Smoke: `wolfxl schema sample-financials.xlsx --sheet "Revenue Breakdown" --format text` correctly tags `Segment` as `categorical`, others as `unique` with sane samples.
- [x] Smoke: default (no `--sheet`) emits JSON with all 3 sheets in the workbook.

## Notes

- PR #8 (cli-agent) is still merge-pending. If #8 lands first, this branch will need a one-line rebase to bring the cli `Cargo.toml` description into agreement (currently mentions `peek/map/schema` only — agent will be added on top after rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)