### PR TITLE
fix: preserve explicit bottom alignment reads

### DIFF
--- a/src/calamine_styled_backend.rs
+++ b/src/calamine_styled_backend.rs
@@ -138,7 +138,7 @@ fn h_align_str(a: &HorizontalAlignment) -> Option<&'static str> {
 /// Convert a calamine VerticalAlignment to the ExcelBench string.
 fn v_align_str(a: &VerticalAlignment) -> Option<&'static str> {
     match a {
-        VerticalAlignment::Bottom => None, // default — omit
+        VerticalAlignment::Bottom => Some("bottom"),
         VerticalAlignment::Top => Some("top"),
         VerticalAlignment::Center => Some("center"),
         VerticalAlignment::Justify => Some("justify"),

--- a/tests/test_wolfxl_compat.py
+++ b/tests/test_wolfxl_compat.py
@@ -169,6 +169,27 @@ class TestReadMode:
         assert fill is not None
         wb.close()
 
+    def test_read_explicit_bottom_alignment(self, tmp_path: Path) -> None:
+        import openpyxl
+        from openpyxl.styles import Alignment
+
+        from wolfxl import load_workbook
+
+        path = tmp_path / "alignment-bottom.xlsx"
+        op_wb = openpyxl.Workbook()
+        ws = op_wb.active
+        assert ws is not None
+        ws["B2"] = "bottom"
+        ws["B2"].alignment = Alignment(vertical="bottom")
+        op_wb.save(path)
+        op_wb.close()
+
+        wb = load_workbook(str(path))
+        ws2 = wb.active
+        assert ws2 is not None
+        assert ws2["B2"].alignment.vertical == "bottom"
+        wb.close()
+
     def test_context_manager(self) -> None:
         from wolfxl import load_workbook
 


### PR DESCRIPTION
## Summary
- Preserve explicit `VerticalAlignment::Bottom` reads in the calamine styled backend instead of treating them as an omitted/default alignment.
- Add a regression test for explicit bottom vertical alignment in read mode.

## Why
ExcelBench's alignment fixture distinguishes explicit `bottom` from omitted/default vertical alignment. WolfXL previously collapsed `VerticalAlignment::Bottom` to `None`, which kept the alignment read score orange even though the workbook explicitly set bottom alignment.

## Validation
- `uv run --with maturin maturin develop --release`
- `uv run pytest tests/test_wolfxl_compat.py::TestReadMode::test_read_explicit_bottom_alignment`
- From ExcelBench after reinstalling local WolfXL: `uv run excelbench benchmark --tests fixtures/excel --output /tmp/excelbench-targeted --feature alignment --adapter wolfxl`
- Full ExcelBench fidelity benchmark after the paired harness fix: WolfXL is now S- with 17/18 green features, and fidelity deltas show 0 regressions / 3 improvements / net +6.