### PR TITLE
chore: prep wolfxl 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] - wolfxl (PyPI cdylib) — follow-up
+## wolfxl 0.5.0 (2026-04-20) - PyPI cdylib parity release
 
 ### Added
 
@@ -48,9 +48,9 @@
   narrower format-category and int/float parity will tighten when
   Option-A collapses the reader paths.
 
-## [Unreleased] - wolfxl (PyPI cdylib)
+### Core Bridge Groundwork
 
-### Added
+#### Added
 
 - **`wolfxl_core_bridge` PyO3 module** (new `src/wolfxl_core_bridge.rs`,
   ~260 LOC). Exposes three `wolfxl-core` classifiers on the `_rust`
@@ -81,7 +81,7 @@
   `infer_sheet_schema` / `classify_sheet` without round-tripping
   through a file.
 
-### Notes
+#### Notes
 
 - **Purely additive surface.** This PR does not replace the duplicate
   per-cell classification calls that already live inside
@@ -93,7 +93,7 @@
   byte-identical results to `wolfxl <subcommand> --format json`. The
   cross-surface parity test lands with task #22b.
 
-## [Unreleased] - wolfxl-core 0.8.0 / wolfxl-cli 0.8.0
+## wolfxl-core 0.8.0 / wolfxl-cli 0.8.0 (2026-04-20)
 
 ### Added
 
@@ -263,7 +263,7 @@
   emitted even when it overflows the budget. We'd rather report the
   overage in the footer than hide workbook structure from the agent.
 
-## 0.5.0 (2026-04-19)
+## wolfxl-core 0.5.0 / wolfxl-cli 0.5.0 (2026-04-19)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "wolfxl"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "calamine-styles",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1"
 
 [package]
 name = "wolfxl"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/docs/trust/release-notes.md
+++ b/docs/trust/release-notes.md
@@ -2,10 +2,17 @@
 
 This page is a release-summary companion to repository release notes.
 
-## Unreleased
+## v0.5.0 - 2026-04-20
 
-- Added first structured WolfXL docs set under `docs/wolfxl/`.
-- Added migration, performance, fidelity, API, operations, and trust sections.
+- Added Python `Worksheet.schema()` and `classify_format()` surfaces backed by
+  `wolfxl-core`, plus cross-surface parity tests against the `wolfxl schema`
+  CLI output.
+- Added the PyO3 `wolfxl_core_bridge` groundwork so Python callers can share
+  classifier and schema inference logic with the Rust CLI/core path.
+- Added `wolfxl-core 0.8.0` / `wolfxl-cli 0.8.0` multi-format dispatch for
+  `.xlsx`, `.xls`, `.xlsb`, `.ods`, and `.csv`.
+- Fixed explicit bottom-alignment reads so Excel-authored `bottom` alignment
+  round-trips instead of collapsing to the default.
 
 ## Release template
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wolfxl"
-version = "0.4.0"
+version = "0.5.0"
 description = "Fast, openpyxl-compatible Excel I/O with Rust backend and built-in formula engine (67 functions, financial, date, time, text, lookup, conditional stats)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "wolfxl"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- bump the PyPI/PyO3 `wolfxl` package version to `0.5.0`
- cut the top changelog entries from Unreleased to dated release entries
- add docs-view release notes for the `0.5.0` parity/core-bridge release
- clarify the older ambiguous `0.5.0` changelog heading as the core/CLI release

## Validation
- `uv run ruff check python/ tests/`
- `uv run pytest` (`626 passed, 10 skipped`)
- `cargo test -p wolfxl-core -p wolfxl-cli --all-targets`
- `uv run --with maturin maturin build --release --out /tmp/wolfxl-dist-0.5.0`
- `uv run --with maturin maturin sdist --out /tmp/wolfxl-sdist-0.5.0`
- clean wheel install/import smoke from `/tmp/wolfxl-dist-0.5.0`

## Release Notes
- PyPI already has `wolfxl==0.4.0`, and `v0.4.0` already points at the older workspace-refactor release, so this prepares the next publishable tag as `v0.5.0`.
- `cargo publish --dry-run --allow-dirty -p wolfxl-core` reached the expected dry-run upload abort.
- `wolfxl-cli` crates dry-run still needs `wolfxl-core 0.8.0` to be published/indexed first, because crates.io only has core up to `0.6.0` right now.
