### PR TITLE
Expose cached formula and visibility read APIs

### DIFF
--- a/python/wolfxl/_workbook.py
+++ b/python/wolfxl/_workbook.py
@@ -176,6 +176,21 @@ class Workbook:
         self._evaluator = ev  # cache for recalculate()
         return result
 
+    def cached_formula_values(self) -> dict[str, Any]:
+        """Return Excel-saved cached formula results for every sheet.
+
+        Keys are workbook-qualified cell references like ``"Sheet1!B2"``.
+        This is a fast read-only path for ingestion workloads that need
+        Excel's last-calculated formula values without evaluating formulas in
+        Python. Cells whose formulas have no cached value are omitted.
+        """
+        if self._rust_reader is None:
+            return {}
+        values: dict[str, Any] = {}
+        for sheet_name in self._sheet_names:
+            values.update(self._sheets[sheet_name].cached_formula_values(qualified=True))
+        return values
+
     def recalculate(
         self,
         perturbations: dict[str, float | int],

--- a/python/wolfxl/_worksheet.py
+++ b/python/wolfxl/_worksheet.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any
 
 from wolfxl._cell import Cell
-from wolfxl._utils import a1_to_rowcol, rowcol_to_a1
+from wolfxl._utils import a1_to_rowcol, column_index, rowcol_to_a1
 
 
 def _canonical_data_type(value: Any) -> str:
@@ -60,6 +60,14 @@ class _RowDimensionProxy:
     def __getitem__(self, row: int) -> _RowDimension:
         return _RowDimension(self._ws, row)
 
+    def get(self, row: int, default: Any = None) -> _RowDimension | Any:
+        if not isinstance(row, int):
+            return default
+        dimension = _RowDimension(self._ws, row)
+        if dimension.height is not None or dimension.hidden or dimension.outline_level:
+            return dimension
+        return default
+
 
 class _RowDimension:
     """Single row dimension with a readable/writable ``height`` property."""
@@ -81,6 +89,24 @@ class _RowDimension:
     def height(self, value: float | None) -> None:
         self._ws._row_heights[self._row] = value  # noqa: SLF001
 
+    @property
+    def hidden(self) -> bool:
+        wb = self._ws._workbook  # noqa: SLF001
+        if wb._rust_reader is not None:  # noqa: SLF001
+            return self._row in self._ws.sheet_visibility()["hidden_rows"]
+        return False
+
+    @property
+    def outlineLevel(self) -> int:  # noqa: N802 - openpyxl public API
+        return self.outline_level
+
+    @property
+    def outline_level(self) -> int:
+        wb = self._ws._workbook  # noqa: SLF001
+        if wb._rust_reader is not None:  # noqa: SLF001
+            return int(self._ws.sheet_visibility()["row_outline_levels"].get(self._row, 0))
+        return 0
+
 
 class _ColumnDimensionProxy:
     """Dict-like proxy: ``ws.column_dimensions['A'].width = 15``."""
@@ -92,6 +118,14 @@ class _ColumnDimensionProxy:
 
     def __getitem__(self, col_letter: str) -> _ColumnDimension:
         return _ColumnDimension(self._ws, col_letter.upper())
+
+    def get(self, col_letter: str, default: Any = None) -> _ColumnDimension | Any:
+        if not isinstance(col_letter, str):
+            return default
+        dimension = _ColumnDimension(self._ws, col_letter.upper())
+        if dimension.width is not None or dimension.hidden or dimension.outline_level:
+            return dimension
+        return default
 
 
 class _ColumnDimension:
@@ -113,6 +147,25 @@ class _ColumnDimension:
     @width.setter
     def width(self, value: float | None) -> None:
         self._ws._col_widths[self._col_letter] = value  # noqa: SLF001
+
+    @property
+    def hidden(self) -> bool:
+        wb = self._ws._workbook  # noqa: SLF001
+        if wb._rust_reader is not None:  # noqa: SLF001
+            return column_index(self._col_letter) in self._ws.sheet_visibility()["hidden_columns"]
+        return False
+
+    @property
+    def outlineLevel(self) -> int:  # noqa: N802 - openpyxl public API
+        return self.outline_level
+
+    @property
+    def outline_level(self) -> int:
+        wb = self._ws._workbook  # noqa: SLF001
+        if wb._rust_reader is not None:  # noqa: SLF001
+            col = column_index(self._col_letter)
+            return int(self._ws.sheet_visibility()["column_outline_levels"].get(col, 0))
+        return 0
 
 
 class _AutoFilter:
@@ -179,7 +232,7 @@ class Worksheet:
         "_append_buffer", "_append_buffer_start", "_bulk_writes",
         "_freeze_panes", "_auto_filter",
         "_row_heights", "_col_widths",
-        "_merged_ranges", "_print_area",
+        "_merged_ranges", "_print_area", "_sheet_visibility_cache",
     )
 
     def __init__(self, workbook: Workbook, title: str) -> None:
@@ -202,6 +255,7 @@ class Worksheet:
         self._col_widths: dict[str, float | None] = {}
         self._merged_ranges: set[str] = set()
         self._print_area: str | None = None
+        self._sheet_visibility_cache: dict[str, Any] | None = None
 
     @property
     def title(self) -> str:
@@ -513,6 +567,7 @@ class Worksheet:
         include_coordinate: bool = True,
         include_style_id: bool = True,
         include_extended_format: bool = True,
+        include_cached_formula_value: bool = False,
     ) -> Iterator[dict[str, Any]]:
         """Iterate populated cells as compact dictionaries.
 
@@ -532,7 +587,9 @@ class Worksheet:
         callers do not need workbook-internal style identifiers. Pass
         ``include_extended_format=False`` to keep raw font flags and number
         formats while skipping expensive style-grid fields such as fill,
-        alignment, and border cues.
+        alignment, and border cues. Pass
+        ``include_cached_formula_value=True`` to include a ``cached_value`` key
+        on formula records that have a saved cached result.
         """
         if self._workbook._rust_reader is None:  # noqa: SLF001
             yield from self._iter_cell_records_python(
@@ -576,6 +633,7 @@ class Worksheet:
             include_coordinate,
             include_style_id,
             include_extended_format,
+            include_cached_formula_value,
         )
 
         # Modify mode can have pending Python-side edits the Rust reader
@@ -611,6 +669,7 @@ class Worksheet:
                 patched["formula"] = new_value[1:]
             else:
                 patched.pop("formula", None)
+            patched.pop("cached_value", None)
             yield patched
 
         # Yield pending edits that were inside the requested range but the
@@ -676,6 +735,7 @@ class Worksheet:
         include_coordinate: bool = True,
         include_style_id: bool = True,
         include_extended_format: bool = True,
+        include_cached_formula_value: bool = False,
     ) -> list[dict[str, Any]]:
         """Return ``iter_cell_records(...)`` as a list."""
         return list(
@@ -691,8 +751,48 @@ class Worksheet:
                 include_coordinate=include_coordinate,
                 include_style_id=include_style_id,
                 include_extended_format=include_extended_format,
+                include_cached_formula_value=include_cached_formula_value,
             ),
         )
+
+    def cached_formula_values(self, *, qualified: bool = False) -> dict[str, Any]:
+        """Return cached formula results for this sheet.
+
+        Keys are A1 coordinates by default. Pass ``qualified=True`` to return
+        ``"Sheet!A1"`` keys, matching :meth:`Workbook.cached_formula_values`.
+        Only formula cells with saved cached values are included; uncached
+        template formulas are omitted.
+        """
+        wb = self._workbook
+        if wb._rust_reader is None:  # noqa: SLF001
+            return {}
+        values = dict(wb._rust_reader.read_cached_formula_values(self._title))  # noqa: SLF001
+        if not qualified:
+            return values
+        return {f"{self._title}!{cell_ref}": value for cell_ref, value in values.items()}
+
+    def sheet_visibility(self) -> dict[str, Any]:
+        """Return hidden rows/columns and outline levels for this sheet.
+
+        Row and column identifiers are 1-based to mirror openpyxl's dimension
+        collections. The returned shape is:
+        ``hidden_rows``, ``hidden_columns``, ``row_outline_levels``, and
+        ``column_outline_levels``.
+        """
+        if self._sheet_visibility_cache is not None:
+            return self._sheet_visibility_cache
+
+        wb = self._workbook
+        if wb._rust_reader is None:  # noqa: SLF001
+            self._sheet_visibility_cache = {
+                "hidden_rows": [],
+                "hidden_columns": [],
+                "row_outline_levels": {},
+                "column_outline_levels": {},
+            }
+            return self._sheet_visibility_cache
+        self._sheet_visibility_cache = dict(wb._rust_reader.read_sheet_visibility(self._title))  # noqa: SLF001
+        return self._sheet_visibility_cache
 
     def _iter_cell_records_python(
         self,

--- a/src/calamine_styled_backend.rs
+++ b/src/calamine_styled_backend.rs
@@ -387,6 +387,10 @@ fn update_bounds(bounds: &mut Option<(u32, u32, u32, u32)>, row: u32, col: u32) 
     }
 }
 
+fn ooxml_attr_truthy(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if v != "0" && !v.eq_ignore_ascii_case("false"))
+}
+
 /// Per-sheet cached data: style grid + layout dimensions.
 struct SheetCache {
     styles: StyleRange,
@@ -428,6 +432,14 @@ struct FreezePaneInfo {
     x_split: Option<i64>,
     y_split: Option<i64>,
     active_pane: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SheetVisibilityInfo {
+    hidden_rows: Vec<u32>,
+    hidden_columns: Vec<u32>,
+    row_outline_levels: Vec<(u32, u8)>,
+    column_outline_levels: Vec<(u32, u8)>,
 }
 
 #[derive(Clone, Debug)]
@@ -647,6 +659,7 @@ impl RecordFormatInfo {
 struct Tier2SheetCache {
     merged_ranges: Option<Vec<String>>,
     merged_bounds: Option<Vec<(u32, u32, u32, u32)>>,
+    visibility: Option<SheetVisibilityInfo>,
     hyperlinks: Option<Vec<HyperlinkInfo>>,
     comments: Option<Vec<CommentInfo>>,
     freeze_panes: Option<FreezePaneInfo>,
@@ -1059,6 +1072,7 @@ impl CalamineStyledBook {
         include_coordinate = true,
         include_style_id = true,
         include_extended_format = true,
+        include_cached_formula_value = false,
     ))]
     pub fn read_sheet_records(
         &mut self,
@@ -1072,6 +1086,7 @@ impl CalamineStyledBook {
         include_coordinate: bool,
         include_style_id: bool,
         include_extended_format: bool,
+        include_cached_formula_value: bool,
     ) -> PyResult<PyObject> {
         self.ensure_sheet_exists(sheet)?;
         if include_format {
@@ -1157,6 +1172,13 @@ impl CalamineStyledBook {
 
                 if let Some(formula_text) = &formula {
                     record.set_item("formula", formula_text)?;
+                    if include_cached_formula_value {
+                        if let Some(v) = &value {
+                            if !matches!(v, Data::Empty) && !value_is_formula_placeholder {
+                                record.set_item("cached_value", data_to_plain_py(py, v)?)?;
+                            }
+                        }
+                    }
                 }
 
                 if should_emit_formula {
@@ -1246,6 +1268,58 @@ impl CalamineStyledBook {
             }
             None => Ok(py.None()),
         }
+    }
+
+    pub fn read_cached_formula_values(
+        &mut self,
+        py: Python<'_>,
+        sheet: &str,
+    ) -> PyResult<PyObject> {
+        self.ensure_sheet_exists(sheet)?;
+        self.ensure_value_caches(sheet)?;
+
+        let out = PyDict::new(py);
+        let formulas: Vec<(u32, u32)> = self
+            .formula_map_cache
+            .get(sheet)
+            .map(|m| m.keys().copied().collect())
+            .unwrap_or_default();
+        let Some(range) = self.range_cache.get(sheet) else {
+            return Ok(out.into());
+        };
+
+        let fmap = self.formula_map_cache.get(sheet);
+        for (row, col) in formulas {
+            let Some(value) = range.get_value((row, col)) else {
+                continue;
+            };
+            if matches!(value, Data::Empty) || is_uncached_formula_value(fmap, row, col, value) {
+                continue;
+            }
+            out.set_item(row_col_to_a1(row, col), data_to_plain_py(py, value)?)?;
+        }
+
+        Ok(out.into())
+    }
+
+    pub fn read_sheet_visibility(&mut self, py: Python<'_>, sheet: &str) -> PyResult<PyObject> {
+        self.ensure_sheet_exists(sheet)?;
+
+        if let Some(info) = self
+            .tier2_cache
+            .get(sheet)
+            .and_then(|cache| cache.visibility.as_ref())
+        {
+            return Self::sheet_visibility_to_py(py, info);
+        }
+
+        let xml = self.sheet_xml_content(sheet)?;
+        let info = Self::parse_sheet_visibility_from_sheet_xml(&xml)?;
+        self.tier2_cache
+            .entry(sheet.to_string())
+            .or_default()
+            .visibility = Some(info.clone());
+        Self::sheet_visibility_to_py(py, &info)
     }
 
     pub fn read_cell_format(
@@ -2070,6 +2144,113 @@ impl CalamineStyledBook {
         }
 
         Ok(out)
+    }
+
+    fn sheet_visibility_to_py(py: Python<'_>, info: &SheetVisibilityInfo) -> PyResult<PyObject> {
+        let d = PyDict::new(py);
+        d.set_item("hidden_rows", info.hidden_rows.clone())?;
+        d.set_item("hidden_columns", info.hidden_columns.clone())?;
+
+        let row_levels = PyDict::new(py);
+        for (row, level) in &info.row_outline_levels {
+            row_levels.set_item(*row, *level)?;
+        }
+        d.set_item("row_outline_levels", row_levels)?;
+
+        let col_levels = PyDict::new(py);
+        for (col, level) in &info.column_outline_levels {
+            col_levels.set_item(*col, *level)?;
+        }
+        d.set_item("column_outline_levels", col_levels)?;
+
+        Ok(d.into())
+    }
+
+    fn parse_sheet_visibility_from_sheet_xml(xml: &str) -> PyResult<SheetVisibilityInfo> {
+        let mut reader = XmlReader::from_str(xml);
+        reader.config_mut().trim_text(true);
+        let mut buf: Vec<u8> = Vec::new();
+        let mut hidden_rows: HashMap<u32, bool> = HashMap::new();
+        let mut hidden_columns: HashMap<u32, bool> = HashMap::new();
+        let mut row_outline_levels: HashMap<u32, u8> = HashMap::new();
+        let mut column_outline_levels: HashMap<u32, u8> = HashMap::new();
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                    let name = e.local_name();
+                    if name.as_ref() == b"col" {
+                        let min_col = ooxml_util::attr_value(e, b"min")
+                            .and_then(|v| v.parse::<u32>().ok())
+                            .unwrap_or(1);
+                        let max_col = ooxml_util::attr_value(e, b"max")
+                            .and_then(|v| v.parse::<u32>().ok())
+                            .unwrap_or(min_col);
+                        let hidden =
+                            ooxml_attr_truthy(ooxml_util::attr_value(e, b"hidden").as_deref());
+                        let outline_level = ooxml_util::attr_value(e, b"outlineLevel")
+                            .and_then(|v| v.parse::<u8>().ok())
+                            .unwrap_or(0);
+                        for col in min_col..=max_col {
+                            hidden_columns.insert(col, hidden);
+                            if outline_level > 0 {
+                                column_outline_levels.insert(col, outline_level);
+                            } else {
+                                column_outline_levels.remove(&col);
+                            }
+                        }
+                    } else if name.as_ref() == b"row" {
+                        let Some(row) =
+                            ooxml_util::attr_value(e, b"r").and_then(|v| v.parse::<u32>().ok())
+                        else {
+                            buf.clear();
+                            continue;
+                        };
+                        let hidden =
+                            ooxml_attr_truthy(ooxml_util::attr_value(e, b"hidden").as_deref());
+                        hidden_rows.insert(row, hidden);
+                        let outline_level = ooxml_util::attr_value(e, b"outlineLevel")
+                            .and_then(|v| v.parse::<u8>().ok())
+                            .unwrap_or(0);
+                        if outline_level > 0 {
+                            row_outline_levels.insert(row, outline_level);
+                        } else {
+                            row_outline_levels.remove(&row);
+                        }
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => {
+                    return Err(PyErr::new::<PyIOError, _>(format!(
+                        "Failed to parse worksheet XML for visibility: {e}"
+                    )))
+                }
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        let mut info = SheetVisibilityInfo {
+            hidden_rows: hidden_rows
+                .into_iter()
+                .filter_map(|(row, hidden)| hidden.then_some(row))
+                .collect(),
+            hidden_columns: hidden_columns
+                .into_iter()
+                .filter_map(|(col, hidden)| hidden.then_some(col))
+                .collect(),
+            row_outline_levels: row_outline_levels.into_iter().collect(),
+            column_outline_levels: column_outline_levels.into_iter().collect(),
+        };
+
+        info.hidden_rows.sort_unstable();
+        info.hidden_columns.sort_unstable();
+        info.row_outline_levels
+            .sort_unstable_by_key(|(row, _)| *row);
+        info.column_outline_levels
+            .sort_unstable_by_key(|(col, _)| *col);
+
+        Ok(info)
     }
 
     fn parse_merged_range_bounds(range_ref: &str) -> Option<(u32, u32, u32, u32)> {

--- a/tests/test_wolfxl_compat.py
+++ b/tests/test_wolfxl_compat.py
@@ -993,6 +993,31 @@ class TestReadMode:
         assert cell_value == expected
         assert row_value == expected
 
+    def test_cached_formula_values_bulk_api(self) -> None:
+        from wolfxl import load_workbook
+
+        path = PARITY_FIXTURES / "time_series" / "ilpa_pe_fund_reporting_v1.1.xlsx"
+        if not path.exists():
+            pytest.skip("parity fixture not found")
+
+        with load_workbook(str(path)) as wb:
+            sheet_values = wb["Reporting Template"].cached_formula_values()
+            workbook_values = wb.cached_formula_values()
+            records = wb["Reporting Template"].cell_records(
+                min_row=4,
+                max_row=4,
+                min_col=5,
+                max_col=5,
+                include_format=False,
+                include_cached_formula_value=True,
+            )
+
+        expected = datetime(2015, 10, 1, 0, 0)
+        assert sheet_values["E4"] == expected
+        assert workbook_values["Reporting Template!E4"] == expected
+        assert records[0]["formula"] == "=P4"
+        assert records[0]["cached_value"] == expected
+
     def test_sheet_dimensions_follow_worksheet_dimension_ref(self) -> None:
         from wolfxl import load_workbook
 
@@ -2398,6 +2423,30 @@ class TestRowDimensions:
         assert abs(h - 25.0) < 1.0
         wb2.close()
 
+    def test_read_hidden_and_outline(self, tmp_path: Path) -> None:
+        from openpyxl import Workbook as OpenPyxlWorkbook
+
+        from wolfxl import load_workbook
+
+        p = tmp_path / "row-visibility.xlsx"
+        wb = OpenPyxlWorkbook()
+        ws = wb.active
+        ws.title = "Visibility"
+        ws["A1"] = "header"
+        ws["A3"] = "hidden"
+        ws.row_dimensions[3].hidden = True
+        ws.row_dimensions[3].outlineLevel = 2
+        wb.save(p)
+
+        with load_workbook(str(p)) as wx_wb:
+            wx_ws = wx_wb["Visibility"]
+            visibility = wx_ws.sheet_visibility()
+            assert visibility["hidden_rows"] == [3]
+            assert visibility["row_outline_levels"] == {3: 2}
+            assert wx_ws.row_dimensions.get(3).hidden is True
+            assert wx_ws.row_dimensions[3].outlineLevel == 2
+            assert wx_ws.row_dimensions.get(2, "missing") == "missing"
+
 
 class TestColumnDimensions:
     """column_dimensions proxy on worksheets."""
@@ -2429,6 +2478,32 @@ class TestColumnDimensions:
         assert w is not None
         assert abs(w - 18.0) < 1.0
         wb2.close()
+
+    def test_read_hidden_and_outline_range(self, tmp_path: Path) -> None:
+        from openpyxl import Workbook as OpenPyxlWorkbook
+
+        from wolfxl import load_workbook
+
+        p = tmp_path / "column-visibility.xlsx"
+        wb = OpenPyxlWorkbook()
+        ws = wb.active
+        ws.title = "Visibility"
+        ws["A1"] = "left"
+        ws["D1"] = "right"
+        ws.column_dimensions["B"].hidden = True
+        ws.column_dimensions["B"].outlineLevel = 1
+        ws.column_dimensions["C"].hidden = True
+        ws.column_dimensions["C"].outlineLevel = 1
+        wb.save(p)
+
+        with load_workbook(str(p)) as wx_wb:
+            wx_ws = wx_wb["Visibility"]
+            visibility = wx_ws.sheet_visibility()
+            assert visibility["hidden_columns"] == [2, 3]
+            assert visibility["column_outline_levels"] == {2: 1, 3: 1}
+            assert wx_ws.column_dimensions.get("B").hidden is True
+            assert wx_ws.column_dimensions["C"].outlineLevel == 1
+            assert wx_ws.column_dimensions.get("D", "missing") == "missing"
 
 
 class TestAutoFilter:


### PR DESCRIPTION
## Summary
- add WolfXL bulk cached formula read APIs at workbook/sheet level
- expose cached formula values inline on `cell_records(..., include_cached_formula_value=True)`
- add row/column hidden and outline metadata via `sheet_visibility()` and dimension proxies
- cover the SynthGL-needed openpyxl read-surface gaps with compat tests

## Validation
- `cargo fmt --check && git diff --check`
- `uv run pytest tests/parity/test_surface_smoke.py tests/parity/test_read_parity.py tests/test_wolfxl_compat.py -q` -> 175 passed, 1 skipped
- focused cached formula/visibility tests -> passed

## Notes
This is the upstream half of the SynthGL XLSX gate cleanup. SynthGL can consume cached formula values and worksheet visibility from WolfXL without loading openpyxl on the ingest hot path.
