### PR TITLE
Support number-format-only cell records

### DIFF
--- a/python/wolfxl/_worksheet.py
+++ b/python/wolfxl/_worksheet.py
@@ -1301,6 +1301,7 @@ class Worksheet:
         include_style_id: bool = True,
         include_extended_format: bool = True,
         include_cached_formula_value: bool = False,
+        include_number_format: bool = False,
     ) -> Iterator[dict[str, Any]]:
         """Iterate populated cells as compact dictionaries.
 
@@ -1321,6 +1322,8 @@ class Worksheet:
         ``include_extended_format=False`` to keep raw font flags and number
         formats while skipping expensive style-grid fields such as fill,
         alignment, and border cues. Pass
+        ``include_number_format=True`` with ``include_format=False`` when only
+        date/currency/percentage format strings are needed. Pass
         ``include_cached_formula_value=True`` to include a ``cached_value`` key
         on formula records that have a saved cached result.
         """
@@ -1332,6 +1335,7 @@ class Worksheet:
                 max_col=max_col,
                 include_empty=include_empty,
                 include_coordinate=include_coordinate,
+                include_number_format=include_number_format or include_format,
             )
             return
 
@@ -1367,6 +1371,7 @@ class Worksheet:
             include_style_id,
             include_extended_format,
             include_cached_formula_value,
+            include_number_format,
         )
 
         # Modify mode can have pending Python-side edits the Rust reader
@@ -1428,6 +1433,10 @@ class Worksheet:
                 extra["formula"] = value[1:]
             if include_coordinate:
                 extra["coordinate"] = rowcol_to_a1(row, col)
+            if include_number_format or include_format:
+                cell = self._cells.get((row, col))
+                if cell is not None and cell.number_format:
+                    extra["number_format"] = cell.number_format
             yield extra
 
     def _collect_pending_overlay(self) -> dict[tuple[int, int], Any]:
@@ -1469,6 +1478,7 @@ class Worksheet:
         include_style_id: bool = True,
         include_extended_format: bool = True,
         include_cached_formula_value: bool = False,
+        include_number_format: bool = False,
     ) -> list[dict[str, Any]]:
         """Return ``iter_cell_records(...)`` as a list."""
         return list(
@@ -1485,6 +1495,7 @@ class Worksheet:
                 include_style_id=include_style_id,
                 include_extended_format=include_extended_format,
                 include_cached_formula_value=include_cached_formula_value,
+                include_number_format=include_number_format,
             ),
         )
 
@@ -1536,6 +1547,7 @@ class Worksheet:
         max_col: int | None,
         include_empty: bool,
         include_coordinate: bool = True,
+        include_number_format: bool = False,
     ) -> Iterator[dict[str, Any]]:
         r_min = min_row or 1
         r_max = max_row or self._max_row()
@@ -1555,6 +1567,8 @@ class Worksheet:
                 }
                 if include_coordinate:
                     record["coordinate"] = rowcol_to_a1(row, col)
+                if include_number_format and cell.number_format:
+                    record["number_format"] = cell.number_format
                 yield record
 
     def calculate_dimension(self) -> str:

--- a/src/calamine_styled_backend.rs
+++ b/src/calamine_styled_backend.rs
@@ -1324,6 +1324,7 @@ impl CalamineStyledBook {
         include_style_id = true,
         include_extended_format = true,
         include_cached_formula_value = false,
+        include_number_format = false,
     ))]
     pub fn read_sheet_records(
         &mut self,
@@ -1338,12 +1339,16 @@ impl CalamineStyledBook {
         include_style_id: bool,
         include_extended_format: bool,
         include_cached_formula_value: bool,
+        include_number_format: bool,
     ) -> PyResult<PyObject> {
         self.ensure_sheet_exists(sheet)?;
         if include_format {
             self.ensure_value_and_style_caches(sheet)?;
         } else {
             self.ensure_value_caches(sheet)?;
+            if include_number_format {
+                self.ensure_cell_style_ids(sheet)?;
+            }
         }
 
         let (start_row, start_col, end_row, end_col) = {
@@ -1424,6 +1429,7 @@ impl CalamineStyledBook {
                     include_style_id,
                     include_extended_format,
                     include_cached_formula_value,
+                    include_number_format,
                 )?;
             }
             return Ok(records.into());
@@ -1461,6 +1467,7 @@ impl CalamineStyledBook {
                     include_style_id,
                     include_extended_format,
                     include_cached_formula_value,
+                    include_number_format,
                 )?;
             }
         }
@@ -2189,6 +2196,7 @@ impl CalamineStyledBook {
         include_style_id: bool,
         include_extended_format: bool,
         include_cached_formula_value: bool,
+        include_number_format: bool,
     ) -> PyResult<()> {
         // calamine writes an empty `<v/>` element on a formula cell as
         // `Some(Data::String(""))`, and renders blank cells inside the
@@ -2256,6 +2264,11 @@ impl CalamineStyledBook {
                         include_style_id,
                         include_extended_format,
                     )?;
+                } else if include_number_format {
+                    let style_id = self.record_style_id(sheet, row, col);
+                    self.populate_record_number_format_for_style_id(
+                        sheet, row, col, style_id, &record,
+                    )?;
                 }
                 records.append(record)?;
                 return Ok(());
@@ -2278,6 +2291,11 @@ impl CalamineStyledBook {
                 &record,
                 include_style_id,
                 include_extended_format,
+            )?;
+        } else if include_number_format {
+            let style_id = self.record_style_id(sheet, row, col);
+            self.populate_record_number_format_for_style_id(
+                sheet, row, col, style_id, &record,
             )?;
         }
 
@@ -2512,6 +2530,29 @@ impl CalamineStyledBook {
             info.populate_dict(d)?;
         }
 
+        Ok(())
+    }
+
+    fn populate_record_number_format_for_style_id(
+        &mut self,
+        sheet: &str,
+        row: u32,
+        col: u32,
+        style_id: Option<u32>,
+        d: &Bound<'_, PyDict>,
+    ) -> PyResult<()> {
+        if self.is_merged_subordinate(sheet, row, col)? {
+            return Ok(());
+        }
+        let Some(style_id) = style_id else {
+            return Ok(());
+        };
+        if style_id == 0 {
+            return Ok(());
+        }
+        if let Some(number_format) = self.resolved_number_format_for_style_id(style_id)? {
+            d.set_item("number_format", number_format)?;
+        }
         Ok(())
     }
 

--- a/src/calamine_xlsb_xls_backend.rs
+++ b/src/calamine_xlsb_xls_backend.rs
@@ -491,6 +491,13 @@ macro_rules! define_calamine_book {
                 _cell_range: Option<&str>,
                 _data_only: bool,
                 _include_format: bool,
+                _include_empty: bool,
+                _include_formula_blanks: bool,
+                _include_coordinate: bool,
+                _include_style_id: bool,
+                _include_extended_format: bool,
+                _include_cached_formula_value: bool,
+                _include_number_format: bool,
             ) -> PyResult<()> {
                 styles_unsupported($format_name)
             }

--- a/tests/test_wolfxl_compat.py
+++ b/tests/test_wolfxl_compat.py
@@ -262,6 +262,44 @@ class TestReadMode:
         assert records["C4"]["data_type"] == "formula"
         assert records["C4"]["formula"] == "=SUM(B2:B2)"
 
+    def test_cell_records_can_emit_number_formats_without_full_format_metadata(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from openpyxl import Workbook
+        from openpyxl.styles import Font
+
+        from wolfxl import load_workbook
+
+        path = tmp_path / "number-format-records.xlsx"
+        op_wb = Workbook()
+        ws = op_wb.active
+        ws.title = "Records"
+        ws["A1"] = "Period"
+        ws["A1"].font = Font(bold=True)
+        ws["A2"] = 45292
+        ws["A2"].number_format = "yyyy-mm-dd"
+        op_wb.save(path)
+        op_wb.close()
+
+        with load_workbook(str(path)) as wb:
+            no_format = {
+                record["coordinate"]: record
+                for record in wb["Records"].cell_records(include_format=False)
+            }
+            number_format_only = {
+                record["coordinate"]: record
+                for record in wb["Records"].cell_records(
+                    include_format=False,
+                    include_number_format=True,
+                )
+            }
+
+        assert "number_format" not in no_format["A2"]
+        assert number_format_only["A2"]["number_format"] == "yyyy-mm-dd"
+        assert "bold" not in number_format_only["A1"]
+        assert "style_id" not in number_format_only["A2"]
+
     def test_cell_records_can_emit_dense_empty_range(self, tmp_path: Path) -> None:
         from openpyxl import Workbook
 


### PR DESCRIPTION
## Summary
- add an opt-in `include_number_format` flag for `cell_records()` / `iter_cell_records()`
- keep existing `include_format=True` behavior unchanged
- let callers request date/currency/percentage number formats without full style metadata

## Validation
- `cargo check`
- `.venv/bin/python -m pytest tests/test_wolfxl_compat.py::TestReadMode::test_cell_records_can_emit_number_formats_without_full_format_metadata tests/test_wolfxl_compat.py::TestReadMode::test_cell_records_exposes_values_and_compact_format_metadata tests/test_wolfxl_compat.py::TestReadMode::test_cell_records_include_formula_blanks_without_coordinate_strings -q`
