### PR TITLE
Support bounded sparse cell records

### DIFF
--- a/python/wolfxl/_worksheet.py
+++ b/python/wolfxl/_worksheet.py
@@ -1342,17 +1342,16 @@ class Worksheet:
         reader = self._workbook._rust_reader  # noqa: SLF001
         effective_data_only = self._workbook._data_only if data_only is None else data_only  # noqa: SLF001
         overlay = self._collect_pending_overlay()
-        unbounded_sparse_read = (
-            min_row is None
-            and max_row is None
-            and min_col is None
-            and max_col is None
-            and not include_empty
+        sparse_record_read = (
+            not include_empty
             and not overlay
+            and (min_row is None or max_row is None or min_col is None or max_col is None)
         )
-        if unbounded_sparse_read:
-            r_min = c_min = 1
-            r_max = c_max = None
+        if sparse_record_read:
+            r_min = min_row or 1
+            r_max = max_row
+            c_min = min_col or 1
+            c_max = max_col
             range_str = None
         else:
             r_min = min_row or 1
@@ -1372,6 +1371,10 @@ class Worksheet:
             include_extended_format,
             include_cached_formula_value,
             include_number_format,
+            r_min if sparse_record_read else None,
+            r_max if sparse_record_read else None,
+            c_min if sparse_record_read else None,
+            c_max if sparse_record_read else None,
         )
 
         # Modify mode can have pending Python-side edits the Rust reader

--- a/src/calamine_styled_backend.rs
+++ b/src/calamine_styled_backend.rs
@@ -431,6 +431,24 @@ fn update_bounds(bounds: &mut Option<(u32, u32, u32, u32)>, row: u32, col: u32) 
     }
 }
 
+fn one_based_bound_to_zero(value: Option<u32>) -> Option<u32> {
+    value.map(|v| v.saturating_sub(1))
+}
+
+fn cell_within_sparse_bounds(
+    row: u32,
+    col: u32,
+    min_row: Option<u32>,
+    max_row: Option<u32>,
+    min_col: Option<u32>,
+    max_col: Option<u32>,
+) -> bool {
+    min_row.is_none_or(|bound| row >= bound)
+        && max_row.is_none_or(|bound| row <= bound)
+        && min_col.is_none_or(|bound| col >= bound)
+        && max_col.is_none_or(|bound| col <= bound)
+}
+
 fn ooxml_attr_truthy(value: Option<&str>) -> bool {
     matches!(value, Some(v) if v != "0" && !v.eq_ignore_ascii_case("false"))
 }
@@ -1325,6 +1343,10 @@ impl CalamineStyledBook {
         include_extended_format = true,
         include_cached_formula_value = false,
         include_number_format = false,
+        sparse_min_row = None,
+        sparse_max_row = None,
+        sparse_min_col = None,
+        sparse_max_col = None,
     ))]
     pub fn read_sheet_records(
         &mut self,
@@ -1340,6 +1362,10 @@ impl CalamineStyledBook {
         include_extended_format: bool,
         include_cached_formula_value: bool,
         include_number_format: bool,
+        sparse_min_row: Option<u32>,
+        sparse_max_row: Option<u32>,
+        sparse_min_col: Option<u32>,
+        sparse_max_col: Option<u32>,
     ) -> PyResult<PyObject> {
         self.ensure_sheet_exists(sheet)?;
         if include_format {
@@ -1378,6 +1404,10 @@ impl CalamineStyledBook {
 
         let records = PyList::empty(py);
         if cell_range.is_none() && !include_empty {
+            let sparse_min_row = one_based_bound_to_zero(sparse_min_row);
+            let sparse_max_row = one_based_bound_to_zero(sparse_max_row);
+            let sparse_min_col = one_based_bound_to_zero(sparse_min_col);
+            let sparse_max_col = one_based_bound_to_zero(sparse_max_col);
             let start = self
                 .range_cache
                 .get(sheet)
@@ -1389,12 +1419,35 @@ impl CalamineStyledBook {
                 for (rel_row, rel_col, value) in range.used_cells() {
                     let row = start.0 + rel_row as u32;
                     let col = start.1 + rel_col as u32;
+                    if sparse_max_row.is_some_and(|bound| row > bound) {
+                        break;
+                    }
+                    if !cell_within_sparse_bounds(
+                        row,
+                        col,
+                        sparse_min_row,
+                        sparse_max_row,
+                        sparse_min_col,
+                        sparse_max_col,
+                    ) {
+                        continue;
+                    }
                     emitted.insert((row, col));
                     cells.push((row, col, Some(value.clone())));
                 }
             }
             if let Some(formulas) = self.formula_map_cache.get(sheet) {
                 for &(row, col) in formulas.keys() {
+                    if !cell_within_sparse_bounds(
+                        row,
+                        col,
+                        sparse_min_row,
+                        sparse_max_row,
+                        sparse_min_col,
+                        sparse_max_col,
+                    ) {
+                        continue;
+                    }
                     if !emitted.contains(&(row, col)) {
                         cells.push((row, col, None));
                     }
@@ -2294,9 +2347,7 @@ impl CalamineStyledBook {
             )?;
         } else if include_number_format {
             let style_id = self.record_style_id(sheet, row, col);
-            self.populate_record_number_format_for_style_id(
-                sheet, row, col, style_id, &record,
-            )?;
+            self.populate_record_number_format_for_style_id(sheet, row, col, style_id, &record)?;
         }
 
         records.append(record)?;

--- a/tests/test_wolfxl_compat.py
+++ b/tests/test_wolfxl_compat.py
@@ -300,6 +300,43 @@ class TestReadMode:
         assert "bold" not in number_format_only["A1"]
         assert "style_id" not in number_format_only["A2"]
 
+    def test_cell_records_can_sparse_scan_with_partial_bounds(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from openpyxl import Workbook
+
+        from wolfxl import load_workbook
+
+        path = tmp_path / "partial-bounds.xlsx"
+        op_wb = Workbook()
+        ws = op_wb.active
+        ws.title = "Records"
+        ws["A1"] = "Header"
+        ws["C2"] = "Inside"
+        ws["A5"] = "Tail"
+        op_wb.save(path)
+        op_wb.close()
+
+        with load_workbook(str(path)) as wb:
+            ws = wb["Records"]
+            monkeypatch.setattr(
+                type(ws),
+                "_max_col",
+                lambda _self: (_ for _ in ()).throw(
+                    AssertionError("max column dimension scan should be skipped")
+                ),
+            )
+
+            records = ws.cell_records(
+                max_row=2,
+                min_col=2,
+                include_format=False,
+            )
+
+        assert [record["coordinate"] for record in records] == ["C2"]
+
     def test_cell_records_can_emit_dense_empty_range(self, tmp_path: Path) -> None:
         from openpyxl import Workbook
 


### PR DESCRIPTION
## Summary
- allow partial row/column bounds to use the sparse Rust record path instead of forcing worksheet dimension discovery
- pass sparse bounds into the Rust reader and filter used cells/formulas there
- add a regression test that fails if a partial-bound sparse read calls _max_col()

## Validation
- cargo check
- uv run --with maturin maturin develop
- .venv/bin/python -m pytest tests/test_wolfxl_compat.py::TestReadMode::test_cell_records_can_sparse_scan_with_partial_bounds tests/test_wolfxl_compat.py::TestReadMode::test_cell_records_can_emit_number_formats_without_full_format_metadata -q

## Downstream SynthGL evidence
- aggregation classify-only profile keeps 97 tables and removes read_sheet_dimensions from the hot path
- cProfile sample: 10.323s prior profile baseline vs 9.673s with bounded sparse records
- 18-workbook strict guard with SynthGL 2,250-row preview: 18/18 passed; aggregation 6.048s; THINK LLP 293 tables preserved