### PR TITLE
Close array formula spill parity surface

### DIFF
--- a/crates/wolfxl-reader/src/lib.rs
+++ b/crates/wolfxl-reader/src/lib.rs
@@ -1082,6 +1082,8 @@ pub enum ArrayFormulaInfo {
         dtr: bool,
         r1: Option<String>,
         r2: Option<String>,
+        del1: bool,
+        del2: bool,
     },
     SpillChild,
 }
@@ -1376,7 +1378,10 @@ impl NativeXlsxBook {
         let threaded_comments = match rels.as_ref() {
             Some(graph) => {
                 let mut acc: Vec<ParsedThreadedComment> = Vec::new();
-                for rel in graph.iter().filter(|rel| rel.rel_type == wolfxl_rels::rt::THREADED_COMMENTS) {
+                for rel in graph
+                    .iter()
+                    .filter(|rel| rel.rel_type == wolfxl_rels::rt::THREADED_COMMENTS)
+                {
                     let path = join_and_normalize(&part_dir(&info.path), &rel.target);
                     if let Some(xml) = read_part_optional(&mut zip, &path)? {
                         acc.extend(parse_threaded_comments(&xml)?);
@@ -1548,7 +1553,10 @@ pub struct ProtectionInfo {
 
 impl Default for ProtectionInfo {
     fn default() -> Self {
-        Self { locked: true, hidden: false }
+        Self {
+            locked: true,
+            hidden: false,
+        }
     }
 }
 
@@ -4293,9 +4301,9 @@ fn parse_threaded_comments(xml: &str) -> Result<Vec<ParsedThreadedComment>> {
             },
             Ok(Event::Text(e)) => {
                 if in_text {
-                    let s = e.unescape().map_err(|err| {
-                        ReaderError::Xml(format!("threadedComments text: {err}"))
-                    })?;
+                    let s = e
+                        .unescape()
+                        .map_err(|err| ReaderError::Xml(format!("threadedComments text: {err}")))?;
                     text_buf.push_str(&s);
                 }
             }
@@ -5670,6 +5678,8 @@ struct CellBuilder {
     formula_dtr: bool,
     formula_r1: Option<String>,
     formula_r2: Option<String>,
+    formula_del1: bool,
+    formula_del2: bool,
     inline_runs: Vec<RichTextRun>,
     inline_current_run: Option<RichTextRun>,
     inline_current_props: Option<InlineFontProps>,
@@ -5710,6 +5720,8 @@ impl CellBuilder {
             formula_dtr: false,
             formula_r1: None,
             formula_r2: None,
+            formula_del1: false,
+            formula_del2: false,
             inline_runs: Vec::new(),
             inline_current_run: None,
             inline_current_props: None,
@@ -5726,6 +5738,8 @@ impl CellBuilder {
         self.formula_dtr = attr_truthy(attr_value(e, b"dtr").as_deref());
         self.formula_r1 = attr_value(e, b"r1");
         self.formula_r2 = attr_value(e, b"r2");
+        self.formula_del1 = attr_truthy(attr_value(e, b"del1").as_deref());
+        self.formula_del2 = attr_truthy(attr_value(e, b"del2").as_deref());
     }
 
     fn push_text(&mut self, target: TextTarget, text: &str) {
@@ -5836,6 +5850,8 @@ impl CellBuilder {
                 dtr: self.formula_dtr,
                 r1: self.formula_r1.clone(),
                 r2: self.formula_r2.clone(),
+                del1: self.formula_del1,
+                del2: self.formula_del2,
             }),
             _ => None,
         };
@@ -6768,7 +6784,10 @@ mod tests {
         assert_eq!(entries[0].person_id, "{A}");
         assert_eq!(entries[0].text, "Looks wrong");
         assert_eq!(entries[0].parent_id, None);
-        assert_eq!(entries[0].created.as_deref(), Some("2026-05-03T12:00:00.000"));
+        assert_eq!(
+            entries[0].created.as_deref(),
+            Some("2026-05-03T12:00:00.000")
+        );
         assert_eq!(entries[1].parent_id.as_deref(), Some("{T1}"));
         assert_eq!(entries[1].text, "Why?");
     }
@@ -6797,5 +6816,4 @@ mod tests {
         assert_eq!(entries[0].done, true);
         assert_eq!(entries[1].done, false);
     }
-
 }

--- a/crates/wolfxl-writer/src/emit/sheet_data.rs
+++ b/crates/wolfxl-writer/src/emit/sheet_data.rs
@@ -212,6 +212,8 @@ fn emit_cell_to<W: fmt::Write>(
             dtr,
             r1,
             r2,
+            del1,
+            del2,
         } => {
             write!(out, "<c r=\"{}\"", cell_ref)?;
             if let Some(s) = cell.style_id {
@@ -233,6 +235,12 @@ fn emit_cell_to<W: fmt::Write>(
             }
             if let Some(r2v) = r2 {
                 write!(out, " r2=\"{}\"", xml_escape::attr(r2v))?;
+            }
+            if *del1 {
+                out.write_str(" del1=\"1\"")?;
+            }
+            if *del2 {
+                out.write_str(" del2=\"1\"")?;
             }
             out.write_str("/></c>")?;
         }

--- a/crates/wolfxl-writer/src/model/cell.rs
+++ b/crates/wolfxl-writer/src/model/cell.rs
@@ -76,6 +76,10 @@ pub enum WriteCellValue {
         r1: Option<String>,
         /// Second input cell (`r2`).
         r2: Option<String>,
+        /// Deleted first input-cell flag (`del1`).
+        del1: bool,
+        /// Deleted second input-cell flag (`del2`).
+        del2: bool,
     },
 
     /// Empty placeholder cell that lives inside an array-formula's spill

--- a/docs/migration/_compat_spec.py
+++ b/docs/migration/_compat_spec.py
@@ -720,10 +720,11 @@ ENTRIES: list[Entry] = [
     {
         "id": "array_formulas.spill",
         "category": "array_formulas",
-        "openpyxl": "dynamic-array spill metadata",
-        "wolfxl": "dynamic-array spill metadata",
-        "status": "partial",
-        "gap_id": "G07",
+        "openpyxl": "Worksheet.array_formulae + DataTableFormula del flags",
+        "wolfxl": "Worksheet.array_formulae + DataTableFormula del flags",
+        "status": "supported",
+        "probe": "array_formula_spill_metadata",
+        "notes": "openpyxl 3.1.5 exposes array/spill ranges via Worksheet.array_formulae; formula_attributes is not part of the supported reference surface.",
     },
     # --- Calc chain -------------------------------------------------------
     {

--- a/docs/migration/compatibility-matrix.md
+++ b/docs/migration/compatibility-matrix.md
@@ -15,8 +15,8 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 
 ## Totals
 
-- ✅ Supported: **66** / 75
-- 🟡 Partial: **2** / 75
+- ✅ Supported: **67** / 75
+- 🟡 Partial: **1** / 75
 - ❌ Not Yet: **1** / 75
 - ⛔ Out of Scope: **6** / 75
 
@@ -189,7 +189,7 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 |---|---|---|---|---|
 | `ArrayFormula(ref, text)` | `ArrayFormula(ref, text)` | ✅ Supported |  | Round-trips through openpyxl reload (ref + text preserved as openpyxl ArrayFormula). |
 | `DataTableFormula(...)` | `DataTableFormula(...)` | ✅ Supported |  |  |
-| `dynamic-array spill metadata` | `dynamic-array spill metadata` | 🟡 Partial | G07 |  |
+| `Worksheet.array_formulae + DataTableFormula del flags` | `Worksheet.array_formulae + DataTableFormula del flags` | ✅ Supported |  | openpyxl 3.1.5 exposes array/spill ranges via Worksheet.array_formulae; formula_attributes is not part of the supported reference surface. |
 
 ## Calc chain
 

--- a/python/wolfxl/_cell.py
+++ b/python/wolfxl/_cell.py
@@ -86,6 +86,8 @@ class Cell:
         "_dt_r",
         "_dt_r1",
         "_dt_r2",
+        "_dt_del1",
+        "_dt_del2",
     )
 
     def __init__(self, ws: Worksheet, row: int, col: int) -> None:
@@ -113,6 +115,8 @@ class Cell:
         self._dt_r: bool = False
         self._dt_r1: str | None = None
         self._dt_r2: str | None = None
+        self._dt_del1: bool = False
+        self._dt_del2: bool = False
 
     @property
     def coordinate(self) -> str:
@@ -554,6 +558,8 @@ class Cell:
                 dtr=payload.get("dtr", False),
                 r1=payload.get("r1"),
                 r2=payload.get("r2"),
+                del1=payload.get("del1", False),
+                del2=payload.get("del2", False),
             )
         return _UNSET
 
@@ -571,6 +577,8 @@ class Cell:
                 dtr=self._dt_r,
                 r1=self._dt_r1,
                 r2=self._dt_r2,
+                del1=self._dt_del1,
+                del2=self._dt_del2,
             )
         if self._formula_type == "array_child":
             return None
@@ -586,6 +594,8 @@ class Cell:
         self._dt_r = False
         self._dt_r1 = None
         self._dt_r2 = None
+        self._dt_del1 = False
+        self._dt_del2 = False
         self._ws._pending_array_formulas.pop((self._row, self._col), None)  # noqa: SLF001
 
     def _queue_array_formula(self, val: Any) -> None:
@@ -617,6 +627,8 @@ class Cell:
         self._dt_r = val.dtr
         self._dt_r1 = val.r1
         self._dt_r2 = val.r2
+        self._dt_del1 = val.del1
+        self._dt_del2 = val.del2
         self._value = val
         self._value_dirty = True
         ws._mark_dirty(self._row, self._col)  # noqa: SLF001
@@ -629,6 +641,8 @@ class Cell:
                 "dtr": val.dtr,
                 "r1": val.r1,
                 "r2": val.r2,
+                "del1": val.del1,
+                "del2": val.del2,
             },
         )
         ws._pending_rich_text.pop((self._row, self._col), None)  # noqa: SLF001
@@ -877,6 +891,8 @@ class Cell:
                 self._dt_r = bool(af_payload.get("dtr", False))
                 self._dt_r1 = af_payload.get("r1")
                 self._dt_r2 = af_payload.get("r2")
+                self._dt_del1 = bool(af_payload.get("del1", False))
+                self._dt_del2 = bool(af_payload.get("del2", False))
             elif kind == "spill_child":
                 self._formula_type = "array_child"
         payload = wb._rust_reader.read_cell_value(  # noqa: SLF001

--- a/python/wolfxl/_worksheet.py
+++ b/python/wolfxl/_worksheet.py
@@ -110,6 +110,7 @@ from wolfxl._worksheet_write_buffers import (
     materialize_bulk_writes,
     write_rows as _write_rows,
 )
+from wolfxl._utils import a1_to_rowcol, rowcol_to_a1
 
 if TYPE_CHECKING:
     from wolfxl._workbook import Workbook
@@ -395,7 +396,32 @@ class Worksheet:
     @property
     def array_formulae(self) -> dict[str, str]:
         """Return array formula ranges by master cell."""
-        return {}
+        out: dict[str, str] = {}
+        reader = getattr(self._workbook, "_rust_reader", None)  # noqa: SLF001
+        if reader is not None and hasattr(reader, "read_sheet_array_formulas"):
+            payloads = reader.read_sheet_array_formulas(self._title)  # noqa: SLF001
+            if isinstance(payloads, dict):
+                for coord, payload in payloads.items():
+                    try:
+                        row_col = a1_to_rowcol(coord)
+                    except ValueError:
+                        row_col = None
+                    cell = self._cells.get(row_col) if row_col is not None else None  # noqa: SLF001
+                    if cell is not None and getattr(cell, "_value_dirty", False):
+                        continue
+                    if isinstance(payload, dict) and payload.get("kind") == "array":
+                        ref = payload.get("ref")
+                        if ref:
+                            out[coord] = ref
+        for (row, col), (kind, payload) in self._pending_array_formulas.items():  # noqa: SLF001
+            if kind == "array":
+                ref = payload.get("ref")
+                if ref:
+                    out[rowcol_to_a1(row, col)] = ref
+        for (row, col), cell in self._cells.items():  # noqa: SLF001
+            if getattr(cell, "_formula_type", None) == "array" and cell._array_ref:  # noqa: SLF001
+                out[rowcol_to_a1(row, col)] = cell._array_ref  # noqa: SLF001
+        return out
 
     @property
     def column_groups(self) -> list[Any]:

--- a/python/wolfxl/_worksheet_patcher_flush.py
+++ b/python/wolfxl/_worksheet_patcher_flush.py
@@ -58,6 +58,8 @@ def flush_to_patcher(
                         "dtr": value.dtr,
                         "r1": value.r1,
                         "r2": value.r2,
+                        "del1": value.del1,
+                        "del2": value.del2,
                     },
                 )
             elif isinstance(value, CellRichText):

--- a/python/wolfxl/_worksheet_writer_flush.py
+++ b/python/wolfxl/_worksheet_writer_flush.py
@@ -203,6 +203,8 @@ def _write_individual_values(
                         "dtr": value.dtr,
                         "r1": value.r1,
                         "r2": value.r2,
+                        "del1": value.del1,
+                        "del2": value.del2,
                     },
                 )
             continue

--- a/python/wolfxl/cell/cell.py
+++ b/python/wolfxl/cell/cell.py
@@ -21,7 +21,7 @@ Pod 1C — Sprint Ο.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 
 class ArrayFormula:
@@ -42,7 +42,7 @@ class ArrayFormula:
 
     __slots__ = ("ref", "text")
 
-    def __init__(self, ref: str, text: str) -> None:
+    def __init__(self, ref: str, text: str | None = None) -> None:
         """Create an array-formula value.
 
         Args:
@@ -55,6 +55,8 @@ class ArrayFormula:
         # convenience — matches openpyxl's coercion.  Also strip
         # surrounding braces so users can paste a CSE formula
         # verbatim from Excel's name box.
+        if text is None:
+            text = ""
         if text.startswith("{=") and text.endswith("}"):
             text = text[2:-1]
         elif text.startswith("="):
@@ -89,7 +91,7 @@ class DataTableFormula:
         r2: Second input cell for 2D tables.
     """
 
-    __slots__ = ("ref", "ca", "dt2D", "dtr", "r1", "r2")
+    __slots__ = ("ref", "ca", "dt2D", "dtr", "r1", "r2", "del1", "del2")
 
     def __init__(
         self,
@@ -99,7 +101,10 @@ class DataTableFormula:
         dtr: bool = False,
         r1: Optional[str] = None,
         r2: Optional[str] = None,
+        del1: bool = False,
+        del2: bool = False,
         t: Optional[str] = None,
+        **kw: Any,
     ) -> None:
         """Create a data-table formula value.
 
@@ -110,8 +115,12 @@ class DataTableFormula:
             dtr: Whether the data-table input is a row.
             r1: First input cell reference.
             r2: Second input cell reference for two-variable tables.
+            del1: Deleted first input-cell flag.
+            del2: Deleted second input-cell flag.
             t: Optional OOXML formula-type discriminator. Accepted for
                 openpyxl API compatibility and ignored.
+            **kw: Additional openpyxl-compatible keyword arguments, accepted
+                and ignored for forwards compatibility.
         """
         if t is not None and t != "dataTable":
             raise ValueError(f"Unsupported data-table formula kind: {t!r}")
@@ -121,6 +130,8 @@ class DataTableFormula:
         self.dtr = bool(dtr)
         self.r1 = r1
         self.r2 = r2
+        self.del1 = bool(del1)
+        self.del2 = bool(del2)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, DataTableFormula):
@@ -132,10 +143,14 @@ class DataTableFormula:
             and self.dtr == other.dtr
             and self.r1 == other.r1
             and self.r2 == other.r2
+            and self.del1 == other.del1
+            and self.del2 == other.del2
         )
 
     def __hash__(self) -> int:
-        return hash((self.ref, self.ca, self.dt2D, self.dtr, self.r1, self.r2))
+        return hash(
+            (self.ref, self.ca, self.dt2D, self.dtr, self.r1, self.r2, self.del1, self.del2)
+        )
 
     def __repr__(self) -> str:
         parts = [f"ref={self.ref!r}"]
@@ -149,6 +164,10 @@ class DataTableFormula:
             parts.append(f"r1={self.r1!r}")
         if self.r2 is not None:
             parts.append(f"r2={self.r2!r}")
+        if self.del1:
+            parts.append(f"del1={self.del1!r}")
+        if self.del2:
+            parts.append(f"del2={self.del2!r}")
         return f"DataTableFormula({', '.join(parts)})"
 
 

--- a/src/native_reader_backend.rs
+++ b/src/native_reader_backend.rs
@@ -293,6 +293,10 @@ impl NativeXlsxBook {
         crate::native_reader_styles::read_cell_array_formula_xlsx(self, py, sheet, a1)
     }
 
+    pub fn read_sheet_array_formulas(&mut self, py: Python<'_>, sheet: &str) -> PyResult<PyObject> {
+        crate::native_reader_styles::read_sheet_array_formulas_xlsx(self, py, sheet)
+    }
+
     pub fn read_cell_rich_text(&mut self, py: Python<'_>, sheet: &str, a1: &str) -> PyResult<PyObject> {
         crate::native_reader_styles::read_cell_rich_text_xlsx(self, py, sheet, a1)
     }
@@ -517,6 +521,10 @@ impl NativeXlsbBook {
 
     pub fn read_cell_array_formula(&mut self, py: Python<'_>, sheet: &str, a1: &str) -> PyResult<PyObject> {
         crate::native_reader_styles::read_cell_array_formula_xlsb(self, py, sheet, a1)
+    }
+
+    pub fn read_sheet_array_formulas(&mut self, py: Python<'_>, sheet: &str) -> PyResult<PyObject> {
+        crate::native_reader_styles::read_sheet_array_formulas_xlsb(self, py, sheet)
     }
 
     pub fn read_cell_format(&mut self, py: Python<'_>, sheet: &str, a1: &str) -> PyResult<PyObject> {

--- a/src/native_reader_styles.rs
+++ b/src/native_reader_styles.rs
@@ -1,8 +1,8 @@
 //! Styles reader logic: fonts, fills, borders, alignment, named-style and
 //! cell-level format readers.
 
-use pyo3::prelude::*;
 use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 use wolfxl_reader::{
@@ -11,7 +11,7 @@ use wolfxl_reader::{
 };
 
 use crate::native_reader_backend::{NativeXlsbBook, NativeXlsxBook};
-use crate::native_reader_dimensions::is_merged_subordinate;
+use crate::native_reader_dimensions::{is_merged_subordinate, row_col_to_a1_1based};
 use crate::native_reader_traits::NativeStyleResolver;
 use crate::util::a1_to_row_col;
 
@@ -141,6 +141,15 @@ pub(crate) fn read_cell_array_formula_xlsx(
     serialize_array_formula(py, info, false)
 }
 
+pub(crate) fn read_sheet_array_formulas_xlsx(
+    book: &mut NativeXlsxBook,
+    py: Python<'_>,
+    sheet: &str,
+) -> PyResult<PyObject> {
+    let data = book.ensure_sheet(sheet)?;
+    serialize_sheet_array_formulas(py, &data.array_formulas, false)
+}
+
 pub(crate) fn read_cell_array_formula_xlsb(
     book: &mut NativeXlsbBook,
     py: Python<'_>,
@@ -160,6 +169,30 @@ pub(crate) fn read_cell_array_formula_xlsb(
     };
     // XLSB applies formula-prefix to array text; XLSX does not.
     serialize_array_formula(py, info, true)
+}
+
+pub(crate) fn read_sheet_array_formulas_xlsb(
+    book: &mut NativeXlsbBook,
+    py: Python<'_>,
+    sheet: &str,
+) -> PyResult<PyObject> {
+    let data = book.ensure_sheet(sheet)?;
+    serialize_sheet_array_formulas(py, &data.array_formulas, true)
+}
+
+fn serialize_sheet_array_formulas(
+    py: Python<'_>,
+    formulas: &std::collections::HashMap<(u32, u32), ArrayFormulaInfo>,
+    prefix_text: bool,
+) -> PyResult<PyObject> {
+    let out = PyDict::new(py);
+    for ((row, col), info) in formulas {
+        out.set_item(
+            row_col_to_a1_1based(*row, *col),
+            serialize_array_formula(py, info.clone(), prefix_text)?,
+        )?;
+    }
+    Ok(out.into())
 }
 
 fn serialize_array_formula(
@@ -188,6 +221,8 @@ fn serialize_array_formula(
             dtr,
             r1,
             r2,
+            del1,
+            del2,
         } => {
             d.set_item("kind", "data_table")?;
             d.set_item("ref", ref_range)?;
@@ -196,6 +231,8 @@ fn serialize_array_formula(
             d.set_item("dtr", dtr)?;
             d.set_item("r1", r1)?;
             d.set_item("r2", r2)?;
+            d.set_item("del1", del1)?;
+            d.set_item("del2", del2)?;
         }
         ArrayFormulaInfo::SpillChild => {
             d.set_item("kind", "spill_child")?;
@@ -419,10 +456,7 @@ pub(crate) fn gradient_to_pydict<'py>(
     Ok(d)
 }
 
-pub(crate) fn populate_alignment(
-    d: &Bound<'_, PyDict>,
-    alignment: &AlignmentInfo,
-) -> PyResult<()> {
+pub(crate) fn populate_alignment(d: &Bound<'_, PyDict>, alignment: &AlignmentInfo) -> PyResult<()> {
     if let Some(value) = &alignment.horizontal {
         d.set_item("h_align", value)?;
     }
@@ -479,4 +513,3 @@ pub(crate) fn set_border_side(
     d.set_item(key, edge)?;
     Ok(())
 }
-

--- a/src/native_writer_cells.rs
+++ b/src/native_writer_cells.rs
@@ -293,6 +293,16 @@ fn array_formula_payload_to_write_cell_value(
                 .unwrap_or(false);
             let r1: Option<String> = payload.get_item("r1")?.and_then(|v| v.extract().ok());
             let r2: Option<String> = payload.get_item("r2")?.and_then(|v| v.extract().ok());
+            let del1: bool = payload
+                .get_item("del1")?
+                .map(|v| v.extract::<bool>())
+                .transpose()?
+                .unwrap_or(false);
+            let del2: bool = payload
+                .get_item("del2")?
+                .map(|v| v.extract::<bool>())
+                .transpose()?
+                .unwrap_or(false);
             WriteCellValue::DataTableFormula {
                 ref_range,
                 ca,
@@ -300,6 +310,8 @@ fn array_formula_payload_to_write_cell_value(
                 dtr,
                 r1,
                 r2,
+                del1,
+                del2,
             }
         }
         "spill_child" => WriteCellValue::SpillChild,

--- a/src/wolfxl/mod.rs
+++ b/src/wolfxl/mod.rs
@@ -606,6 +606,16 @@ impl XlsxPatcher {
                     .unwrap_or(false);
                 let r1: Option<String> = payload.get_item("r1")?.and_then(|v| v.extract().ok());
                 let r2: Option<String> = payload.get_item("r2")?.and_then(|v| v.extract().ok());
+                let del1: bool = payload
+                    .get_item("del1")?
+                    .map(|v| v.extract::<bool>())
+                    .transpose()?
+                    .unwrap_or(false);
+                let del2: bool = payload
+                    .get_item("del2")?
+                    .map(|v| v.extract::<bool>())
+                    .transpose()?
+                    .unwrap_or(false);
                 CellValue::DataTableFormula {
                     ref_range,
                     ca,
@@ -613,6 +623,8 @@ impl XlsxPatcher {
                     dtr,
                     r1,
                     r2,
+                    del1,
+                    del2,
                 }
             }
             "spill_child" => CellValue::SpillChild,
@@ -1471,9 +1483,11 @@ impl XlsxPatcher {
             }
         }
 
-        let op = threaded_comments::ThreadedCommentOp::Set(
-            threaded_comments::ThreadedCommentPatch { top, replies },
-        );
+        let op =
+            threaded_comments::ThreadedCommentOp::Set(threaded_comments::ThreadedCommentPatch {
+                top,
+                replies,
+            });
         self.queued_threaded_comments
             .entry(sheet.to_string())
             .or_default()
@@ -1488,7 +1502,10 @@ impl XlsxPatcher {
         self.queued_threaded_comments
             .entry(sheet.to_string())
             .or_default()
-            .insert(cell.to_string(), threaded_comments::ThreadedCommentOp::Delete);
+            .insert(
+                cell.to_string(),
+                threaded_comments::ThreadedCommentOp::Delete,
+            );
         Ok(())
     }
 
@@ -1503,7 +1520,9 @@ impl XlsxPatcher {
         let id = extract_str(payload, "id")?
             .ok_or_else(|| PyValueError::new_err("queue_person: missing 'id'"))?;
         if id.is_empty() {
-            return Err(PyValueError::new_err("queue_person: 'id' must be non-empty"));
+            return Err(PyValueError::new_err(
+                "queue_person: 'id' must be non-empty",
+            ));
         }
         let display_name = extract_str(payload, "name")?.unwrap_or_default();
         let user_id = extract_str(payload, "user_id")?.unwrap_or_default();
@@ -1717,9 +1736,7 @@ impl XlsxPatcher {
             Ok(mut f) => {
                 let mut buf = Vec::with_capacity(f.size() as usize);
                 std::io::Read::read_to_end(&mut f, &mut buf).map_err(|e| {
-                    PyErr::new::<PyIOError, _>(format!(
-                        "Failed to read xl/vbaProject.bin: {e}"
-                    ))
+                    PyErr::new::<PyIOError, _>(format!("Failed to read xl/vbaProject.bin: {e}"))
                 })?;
                 Some(buf)
             }
@@ -2228,7 +2245,11 @@ impl XlsxPatcher {
         // session is touched in its post-adds form. The phase is a
         // no-op when no edits have been registered.
         if !self.queued_pivot_source_edits.is_empty() {
-            patcher_pivot_edit::apply_pivot_source_edits_phase(self, &mut save.file_patches, &mut zip)?;
+            patcher_pivot_edit::apply_pivot_source_edits_phase(
+                self,
+                &mut save.file_patches,
+                &mut zip,
+            )?;
         }
 
         // --- Phase 2.5n: Sheet setup (Sprint Ο Pod 1A.5 / RFC-055) ---

--- a/src/wolfxl/sheet_patcher.rs
+++ b/src/wolfxl/sheet_patcher.rs
@@ -53,6 +53,8 @@ pub enum CellValue {
         dtr: bool,
         r1: Option<String>,
         r2: Option<String>,
+        del1: bool,
+        del2: bool,
     },
     /// RFC-057: bare placeholder cell that lives inside an
     /// array-formula's spill range (everything except the master).
@@ -531,6 +533,8 @@ fn write_patched_cell<W: Write>(
             dtr,
             r1,
             r2,
+            del1,
+            del2,
         }) => {
             // RFC-057: <c r="..."><f t="dataTable" ref=".." dt2D="1" r1=".." r2=".."/></c>
             writer
@@ -553,6 +557,12 @@ fn write_patched_cell<W: Write>(
             }
             if let Some(rv) = r2.as_ref() {
                 f_empty.push_attribute(("r2", rv.as_str()));
+            }
+            if *del1 {
+                f_empty.push_attribute(("del1", "1"));
+            }
+            if *del2 {
+                f_empty.push_attribute(("del2", "1"));
             }
             writer
                 .write_event(Event::Empty(f_empty))

--- a/tests/parity/test_array_formula_parity.py
+++ b/tests/parity/test_array_formula_parity.py
@@ -63,6 +63,21 @@ def test_openpyxl_writes_array_wolfxl_reads(tmp_path: Path) -> None:
     # openpyxl emits the body with leading "=" — wolfxl strips it on
     # parse.  Accept either.
     assert "B1:B3*2" in a1.text
+    assert rb.active.array_formulae == {"A1": "A1:A3"}
+
+
+def test_wolfxl_matches_openpyxl_array_formulae_property(tmp_path: Path) -> None:
+    """openpyxl 3.1.x exposes spill metadata via ``Worksheet.array_formulae``."""
+    p = tmp_path / "array_formulae.xlsx"
+    wb = wolfxl.Workbook()
+    wb.active["A1"] = ArrayFormula("A1:A3")
+    wb.save(str(p))
+
+    rb = wolfxl.load_workbook(str(p))
+    assert rb.active.array_formulae == {"A1": "A1:A3"}
+
+    op = openpyxl.load_workbook(str(p))
+    assert op.active.array_formulae == {"A1": "A1:A3"}
 
 
 def test_wolfxl_writes_data_table_openpyxl_reads(tmp_path: Path) -> None:
@@ -84,6 +99,24 @@ def test_wolfxl_writes_data_table_openpyxl_reads(tmp_path: Path) -> None:
         # either bool or string truthy.
         assert val.dt2D in (True, "1", 1)
     # Either way, the file must round-trip cleanly without raising.
+
+
+def test_data_table_del_flags_round_trip_with_openpyxl(tmp_path: Path) -> None:
+    p = tmp_path / "dt_del_flags.xlsx"
+    wb = wolfxl.Workbook()
+    wb.active["B2"] = DataTableFormula(ref="B2:F11", del1=True, del2=True)
+    wb.save(str(p))
+
+    rb = wolfxl.load_workbook(str(p))
+    val = rb.active["B2"].value
+    assert isinstance(val, DataTableFormula)
+    assert val.del1 is True
+    assert val.del2 is True
+
+    op = openpyxl.load_workbook(str(p))
+    op_val = op.active["B2"].value
+    assert str(op_val.del1).lower() in {"1", "true"}
+    assert str(op_val.del2).lower() in {"1", "true"}
 
 
 def test_round_trip_preserves_neighbors_modify_mode(tmp_path: Path) -> None:

--- a/tests/test_array_formula.py
+++ b/tests/test_array_formula.py
@@ -32,6 +32,12 @@ def test_constructor_positional() -> None:
     assert af.text == "SUM(B1:B10*C1:C10)"
 
 
+def test_constructor_text_optional() -> None:
+    af = ArrayFormula("A1:A10")
+    assert af.ref == "A1:A10"
+    assert af.text == ""
+
+
 def test_constructor_strips_leading_equals() -> None:
     af = ArrayFormula("A1:A10", "=B1:B10*2")
     assert af.text == "B1:B10*2"
@@ -169,6 +175,36 @@ def test_round_trip_write_mode(tmp_path: Path) -> None:
     # Untouched neighbor cells survive.
     assert reloaded.active["B1"].value == 1
     assert reloaded.active["B3"].value == 3
+    assert reloaded.active.array_formulae == {"A1": "A1:A3"}
+
+
+def test_array_formulae_uses_reader_index_not_grid_scan() -> None:
+    class FakeReader:
+        def read_sheet_array_formulas(self, sheet: str) -> dict[str, dict[str, str]]:
+            assert sheet == "Sheet"
+            return {"A1": {"kind": "array", "ref": "A1:A3"}}
+
+        def read_cell_array_formula(self, sheet: str, coord: str) -> None:
+            raise AssertionError(f"unexpected per-cell array formula probe for {sheet}!{coord}")
+
+    wb = wolfxl.Workbook()
+    ws = wb.active
+    ws["ZZ2000"] = "force a large sparse used range"
+    wb._rust_reader = FakeReader()  # noqa: SLF001
+
+    assert ws.array_formulae == {"A1": "A1:A3"}
+
+
+def test_array_formulae_excludes_overwritten_reader_formula(tmp_path: Path) -> None:
+    src = tmp_path / "src.xlsx"
+    wb = wolfxl.Workbook()
+    wb.active["A1"] = ArrayFormula("A1:A3", "B1:B3*2")
+    wb.save(str(src))
+
+    loaded = wolfxl.load_workbook(str(src), modify=True)
+    loaded.active["A1"] = 123
+
+    assert loaded.active.array_formulae == {}
 
 
 def test_round_trip_modify_mode(tmp_path: Path) -> None:

--- a/tests/test_data_table_formula.py
+++ b/tests/test_data_table_formula.py
@@ -28,6 +28,14 @@ def test_constructor_minimal() -> None:
     assert dt.dtr is False
     assert dt.r1 is None
     assert dt.r2 is None
+    assert dt.del1 is False
+    assert dt.del2 is False
+
+
+def test_constructor_accepts_openpyxl_del_flags_and_extra_kwargs() -> None:
+    dt = DataTableFormula(ref="B2:F11", del1=True, del2=True, aca=True)
+    assert dt.del1 is True
+    assert dt.del2 is True
 
 
 def test_constructor_2d() -> None:
@@ -130,6 +138,8 @@ def test_round_trip_preserves_all_data_table_attrs(tmp_path: Path) -> None:
         dtr=True,
         r1="A1",
         r2="B1",
+        del1=True,
+        del2=True,
     )
     wb.save(str(p))
 
@@ -142,6 +152,8 @@ def test_round_trip_preserves_all_data_table_attrs(tmp_path: Path) -> None:
     assert val.dtr is True
     assert val.r1 == "A1"
     assert val.r2 == "B1"
+    assert val.del1 is True
+    assert val.del2 is True
 
     ref_wb = _opx.load_workbook(str(p))
     ref_val = ref_wb.active["C1"].value
@@ -152,6 +164,8 @@ def test_round_trip_preserves_all_data_table_attrs(tmp_path: Path) -> None:
     assert str(ref_val.dtr).lower() in {"1", "true"}
     assert ref_val.r1 == "A1"
     assert ref_val.r2 == "B1"
+    assert str(ref_val.del1).lower() in {"1", "true"}
+    assert str(ref_val.del2).lower() in {"1", "true"}
 
 
 def test_round_trip_modify_mode(tmp_path: Path) -> None:

--- a/tests/test_openpyxl_compat_oracle.py
+++ b/tests/test_openpyxl_compat_oracle.py
@@ -1518,6 +1518,38 @@ def _probe_array_formula_data_table(tmp_path: Path) -> None:
     assert val is not None
 
 
+@_register("array_formula_spill_metadata")
+def _probe_array_formula_spill_metadata(tmp_path: Path) -> None:
+    """openpyxl 3.1.x array/spill metadata surface parity."""
+    import openpyxl as _opx
+    from openpyxl.worksheet.formula import DataTableFormula as _OpxDataTableFormula
+    import wolfxl
+    from wolfxl.worksheet.formula import ArrayFormula, DataTableFormula
+
+    wb = wolfxl.Workbook()
+    ws = wb.active
+    ws["A1"] = ArrayFormula(ref="A1:A3")
+    ws["B2"] = DataTableFormula(ref="B2:B4", del1=True, del2=True, aca=True)
+    out = tmp_path / "array_spill_metadata.xlsx"
+    wb.save(out)
+
+    wolf_rt = wolfxl.load_workbook(out)
+    wolf_ws = wolf_rt.active
+    assert wolf_ws.array_formulae == {"A1": "A1:A3"}
+    wolf_dt = wolf_ws["B2"].value
+    assert isinstance(wolf_dt, DataTableFormula)
+    assert wolf_dt.del1 is True
+    assert wolf_dt.del2 is True
+
+    op_rt = _opx.load_workbook(out)
+    op_ws = op_rt.active
+    assert op_ws.array_formulae == {"A1": "A1:A3"}
+    op_dt = op_ws["B2"].value
+    assert isinstance(op_dt, _OpxDataTableFormula)
+    assert str(op_dt.del1).lower() in {"1", "true"}
+    assert str(op_dt.del2).lower() in {"1", "true"}
+
+
 # --------------------------------------------------------------------------
 # Test runner / parametrisation
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- implement openpyxl-compatible array formula spill metadata via Worksheet.array_formulae
- round-trip data-table formula deletion flags through reader, writer, patcher, and Python cell payloads
- promote the array_formula_spill_metadata compat matrix row from partial to supported

## Validation
- uv run --no-sync python -m pytest tests/test_array_formula.py tests/test_data_table_formula.py tests/parity/test_array_formula_parity.py -q
- uv run --no-sync python -m pytest tests/test_openpyxl_compat_oracle.py -k array_formula -q
- uv run --no-sync python -m pytest tests/test_openpyxl_compat_oracle.py -q
- cargo test --workspace --quiet
- uv run --no-sync ruff check python/wolfxl tests/test_array_formula.py tests/test_data_table_formula.py tests/parity/test_array_formula_parity.py tests/test_openpyxl_compat_oracle.py
- git diff --check

## Notes
This intentionally follows openpyxl 3.1.5 behavior: array spill metadata is exposed through Worksheet.array_formulae, not Worksheet.formula_attributes.