### PR TITLE
Close remaining openpyxl replacement workflow gaps

### DIFF
--- a/crates/wolfxl-reader/src/lib.rs
+++ b/crates/wolfxl-reader/src/lib.rs
@@ -1401,6 +1401,25 @@ impl NativeXlsxBook {
         data.threaded_comments = threaded_comments;
         Ok(data)
     }
+
+    /// Parse charts attached to a chartsheet tab.
+    pub fn chartsheet_charts(&self, sheet_name: &str) -> Result<Vec<ChartInfo>> {
+        let Some(info) = self
+            .sheets
+            .iter()
+            .find(|s| s.name == sheet_name && s.path.contains("chartsheets/"))
+        else {
+            return Err(ReaderError::SheetNotFound(sheet_name.to_string()));
+        };
+        let mut zip = zip_from_bytes(&self.bytes)?;
+        let rels = read_part_optional(&mut zip, &sheet_rels_path(&info.path))?
+            .map(|xml| {
+                RelsGraph::parse(xml.as_bytes())
+                    .map_err(|e| ReaderError::Xml(format!("failed to parse chartsheet rels: {e}")))
+            })
+            .transpose()?;
+        read_charts(&mut zip, &info.path, rels.as_ref())
+    }
 }
 
 #[derive(Debug)]

--- a/docs/migration/_compat_spec.py
+++ b/docs/migration/_compat_spec.py
@@ -148,6 +148,24 @@ ENTRIES: list[Entry] = [
         "probe": "workbook_create_sheet",
     },
     {
+        "id": "workbook.create_sheet_modify",
+        "category": "workbook",
+        "openpyxl": "wb.create_sheet(title, index=...) on loaded workbook",
+        "wolfxl": "wb.create_sheet(title, index=...) on modify=True workbook",
+        "status": "supported",
+        "probe": "workbook_create_sheet_modify",
+        "notes": "Modify-mode blank sheet creation updates workbook.xml, workbook rels, content-types, tab order, and accepts cell edits before save.",
+    },
+    {
+        "id": "workbook.remove_sheet_modify",
+        "category": "workbook",
+        "openpyxl": "wb.remove(ws) on loaded workbook",
+        "wolfxl": "wb.remove(ws) on modify=True workbook",
+        "status": "supported",
+        "probe": "workbook_remove_sheet_modify",
+        "notes": "Modify-mode sheet removal prunes the workbook tab, workbook rel, worksheet part, local defined-name indexes, and reachable sheet subgraph parts.",
+    },
+    {
         "id": "workbook.rename_sheet_modify",
         "category": "workbook",
         "openpyxl": "ws.title = 'Renamed' on loaded workbook",
@@ -269,7 +287,7 @@ ENTRIES: list[Entry] = [
         "wolfxl": "ws.add_chart / remove_chart / replace_chart",
         "status": "supported",
         "probe": "charts_add_remove_replace",
-        "notes": "remove/replace shipped in v1.7.",
+        "notes": "Covers pending charts plus source-loaded worksheet chart removal, replacement, and title edits in modify mode.",
     },
     {
         "id": "charts.chartsheet",
@@ -559,7 +577,8 @@ ENTRIES: list[Entry] = [
         "notes": (
             "Inspection (target / sheet_names / cached_data), opaque "
             "modify-mode preservation when unchanged, and append/remove/edit "
-            "authoring."
+            "authoring. keep_links=False strips preserved source links, and "
+            "file-like/bytes-backed xlsx reads expose the same collection."
         ),
     },
     {

--- a/docs/migration/_compat_spec.py
+++ b/docs/migration/_compat_spec.py
@@ -262,6 +262,15 @@ ENTRIES: list[Entry] = [
         "notes": "remove/replace shipped in v1.7.",
     },
     {
+        "id": "charts.chartsheet",
+        "category": "charts",
+        "openpyxl": "wb.create_chartsheet(...).add_chart(chart)",
+        "wolfxl": "wb.create_chartsheet(...).add_chart(chart)",
+        "status": "supported",
+        "probe": "charts_chartsheet",
+        "notes": "Write-mode chartsheet authoring emits chartsheet, drawing, chart, rels, and content-type parts that openpyxl reloads as workbook.chartsheets.",
+    },
+    {
         "id": "charts.combination",
         "category": "charts",
         "openpyxl": "bar + line on shared category axis with secondary value axis",

--- a/docs/migration/_compat_spec.py
+++ b/docs/migration/_compat_spec.py
@@ -129,6 +129,7 @@ ENTRIES: list[Entry] = [
         "wolfxl": "wb.save(path)",
         "status": "supported",
         "probe": "workbook_save_basic",
+        "notes": "Eager workbooks can be edited and saved repeatedly; write_only=True remains consumed-on-save like openpyxl.",
     },
     {
         "id": "workbook.sheet_access",
@@ -145,6 +146,15 @@ ENTRIES: list[Entry] = [
         "wolfxl": "wb.create_sheet(title)",
         "status": "supported",
         "probe": "workbook_create_sheet",
+    },
+    {
+        "id": "workbook.rename_sheet_modify",
+        "category": "workbook",
+        "openpyxl": "ws.title = 'Renamed' on loaded workbook",
+        "wolfxl": "ws.title = 'Renamed' on modify=True workbook",
+        "status": "supported",
+        "probe": "workbook_rename_sheet_modify",
+        "notes": "Modify-mode sheet title changes update workbook.xml and subsequent queued sheet mutations target the renamed tab.",
     },
     {
         "id": "workbook.copy_worksheet",
@@ -268,7 +278,7 @@ ENTRIES: list[Entry] = [
         "wolfxl": "wb.create_chartsheet(...).add_chart(chart)",
         "status": "supported",
         "probe": "charts_chartsheet",
-        "notes": "Write-mode chartsheet authoring emits chartsheet, drawing, chart, rels, and content-type parts that openpyxl reloads as workbook.chartsheets.",
+        "notes": "Chartsheet authoring emits chartsheet, drawing, chart, rels, and content-type parts that openpyxl reloads; existing chartsheet tabs load back as workbook.chartsheets rather than worksheets.",
     },
     {
         "id": "charts.combination",

--- a/docs/migration/compatibility-matrix.md
+++ b/docs/migration/compatibility-matrix.md
@@ -15,10 +15,10 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 
 ## Totals
 
-- ✅ Supported: **73** / 80
-- 🟡 Partial: **0** / 80
-- ❌ Not Yet: **0** / 80
-- ⛔ Out of Scope: **7** / 80
+- ✅ Supported: **74** / 81
+- 🟡 Partial: **0** / 81
+- ❌ Not Yet: **0** / 81
+- ⛔ Out of Scope: **7** / 81
 
 ## Workbook + Worksheet
 
@@ -29,9 +29,10 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 | `load_workbook(path, data_only=True)` | `wolfxl.load_workbook(path, data_only=True)` | ✅ Supported |  |  |
 | `Implicit (full DOM rewrite)` | `wolfxl.load_workbook(path, modify=True)` | ✅ Supported |  | Surgical patcher; faster than DOM rewrite. |
 | `load_workbook(path, read_only=True)` | `wolfxl.load_workbook(path, read_only=True)` | ✅ Supported |  | Streaming reads (auto-engages > 50k rows). |
-| `wb.save(path)` | `wb.save(path)` | ✅ Supported |  |  |
+| `wb.save(path)` | `wb.save(path)` | ✅ Supported |  | Eager workbooks can be edited and saved repeatedly; write_only=True remains consumed-on-save like openpyxl. |
 | `wb["Sheet"], wb.active, wb.sheetnames` | `wb["Sheet"], wb.active, wb.sheetnames` | ✅ Supported |  |  |
 | `wb.create_sheet(title)` | `wb.create_sheet(title)` | ✅ Supported |  |  |
+| `ws.title = 'Renamed' on loaded workbook` | `ws.title = 'Renamed' on modify=True workbook` | ✅ Supported |  | Modify-mode sheet title changes update workbook.xml and subsequent queued sheet mutations target the renamed tab. |
 | `wb.copy_worksheet(ws)` | `wb.copy_worksheet(ws)` | ✅ Supported |  | Diverges from openpyxl in 5 documented ways (always more preservation). |
 
 ## Cell + style API
@@ -54,7 +55,7 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 | `BarChart3D / LineChart3D / PieChart3D / AreaChart3D` | `BarChart3D / LineChart3D / PieChart3D / AreaChart3D` | ✅ Supported |  |  |
 | `SurfaceChart / SurfaceChart3D / StockChart / ProjectedPieChart` | `SurfaceChart / SurfaceChart3D / StockChart / ProjectedPieChart` | ✅ Supported |  |  |
 | `ws.add_chart / remove_chart / replace_chart` | `ws.add_chart / remove_chart / replace_chart` | ✅ Supported |  | remove/replace shipped in v1.7. |
-| `wb.create_chartsheet(...).add_chart(chart)` | `wb.create_chartsheet(...).add_chart(chart)` | ✅ Supported |  | Write-mode chartsheet authoring emits chartsheet, drawing, chart, rels, and content-type parts that openpyxl reloads as workbook.chartsheets. |
+| `wb.create_chartsheet(...).add_chart(chart)` | `wb.create_chartsheet(...).add_chart(chart)` | ✅ Supported |  | Chartsheet authoring emits chartsheet, drawing, chart, rels, and content-type parts that openpyxl reloads; existing chartsheet tabs load back as workbook.chartsheets rather than worksheets. |
 | `bar + line on shared category axis with secondary value axis` | `bar + line on shared category axis with secondary value axis` | ✅ Supported |  | Combination charts ship as a multi-family `<plotArea>` (RFC-069 §6) for real Excel/LibreOffice rendering, plus per-family standalone shadow chartspaces parked at row 1048576 so openpyxl's reader exposes each family as a distinct `ws._charts` entry without the shadows visually overlapping the real combo. Secondary value axis (right side) honored when `line.y_axis.crosses='max'` and `line.y_axis.axId` is set. Closes G15. |
 | `data label + axis label rich-text runs` | `data label + axis label rich-text runs` | ✅ Supported | G10 | Data label `<c:txPr>` runs and axis-title rich text round-trip end-to-end (G10). |
 | `pivot chart with per-point overrides` | `pivot chart with per-point overrides` | ✅ Supported |  | Per-point `<c:dPt>` overrides round-trip through openpyxl on pivot-source charts (G16). Bar/line/scatter all share the same dict bridge: `Series.dPt` -> `data_points` -> Rust `DataPoint` -> `<c:dPt>` with `<c:spPr>`. Pivot vs non-pivot only differ in the chart-level `<c:pivotSource>` block. |

--- a/docs/migration/compatibility-matrix.md
+++ b/docs/migration/compatibility-matrix.md
@@ -15,10 +15,10 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 
 ## Totals
 
-- ✅ Supported: **72** / 79
-- 🟡 Partial: **0** / 79
-- ❌ Not Yet: **0** / 79
-- ⛔ Out of Scope: **7** / 79
+- ✅ Supported: **73** / 80
+- 🟡 Partial: **0** / 80
+- ❌ Not Yet: **0** / 80
+- ⛔ Out of Scope: **7** / 80
 
 ## Workbook + Worksheet
 
@@ -54,6 +54,7 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 | `BarChart3D / LineChart3D / PieChart3D / AreaChart3D` | `BarChart3D / LineChart3D / PieChart3D / AreaChart3D` | ✅ Supported |  |  |
 | `SurfaceChart / SurfaceChart3D / StockChart / ProjectedPieChart` | `SurfaceChart / SurfaceChart3D / StockChart / ProjectedPieChart` | ✅ Supported |  |  |
 | `ws.add_chart / remove_chart / replace_chart` | `ws.add_chart / remove_chart / replace_chart` | ✅ Supported |  | remove/replace shipped in v1.7. |
+| `wb.create_chartsheet(...).add_chart(chart)` | `wb.create_chartsheet(...).add_chart(chart)` | ✅ Supported |  | Write-mode chartsheet authoring emits chartsheet, drawing, chart, rels, and content-type parts that openpyxl reloads as workbook.chartsheets. |
 | `bar + line on shared category axis with secondary value axis` | `bar + line on shared category axis with secondary value axis` | ✅ Supported |  | Combination charts ship as a multi-family `<plotArea>` (RFC-069 §6) for real Excel/LibreOffice rendering, plus per-family standalone shadow chartspaces parked at row 1048576 so openpyxl's reader exposes each family as a distinct `ws._charts` entry without the shadows visually overlapping the real combo. Secondary value axis (right side) honored when `line.y_axis.crosses='max'` and `line.y_axis.axId` is set. Closes G15. |
 | `data label + axis label rich-text runs` | `data label + axis label rich-text runs` | ✅ Supported | G10 | Data label `<c:txPr>` runs and axis-title rich text round-trip end-to-end (G10). |
 | `pivot chart with per-point overrides` | `pivot chart with per-point overrides` | ✅ Supported |  | Per-point `<c:dPt>` overrides round-trip through openpyxl on pivot-source charts (G16). Bar/line/scatter all share the same dict bridge: `Series.dPt` -> `data_points` -> Rust `DataPoint` -> `<c:dPt>` with `<c:spPr>`. Pivot vs non-pivot only differ in the chart-level `<c:pivotSource>` block. |

--- a/docs/migration/compatibility-matrix.md
+++ b/docs/migration/compatibility-matrix.md
@@ -15,10 +15,10 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 
 ## Totals
 
-- ✅ Supported: **74** / 81
-- 🟡 Partial: **0** / 81
-- ❌ Not Yet: **0** / 81
-- ⛔ Out of Scope: **7** / 81
+- ✅ Supported: **76** / 83
+- 🟡 Partial: **0** / 83
+- ❌ Not Yet: **0** / 83
+- ⛔ Out of Scope: **7** / 83
 
 ## Workbook + Worksheet
 
@@ -32,6 +32,8 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 | `wb.save(path)` | `wb.save(path)` | ✅ Supported |  | Eager workbooks can be edited and saved repeatedly; write_only=True remains consumed-on-save like openpyxl. |
 | `wb["Sheet"], wb.active, wb.sheetnames` | `wb["Sheet"], wb.active, wb.sheetnames` | ✅ Supported |  |  |
 | `wb.create_sheet(title)` | `wb.create_sheet(title)` | ✅ Supported |  |  |
+| `wb.create_sheet(title, index=...) on loaded workbook` | `wb.create_sheet(title, index=...) on modify=True workbook` | ✅ Supported |  | Modify-mode blank sheet creation updates workbook.xml, workbook rels, content-types, tab order, and accepts cell edits before save. |
+| `wb.remove(ws) on loaded workbook` | `wb.remove(ws) on modify=True workbook` | ✅ Supported |  | Modify-mode sheet removal prunes the workbook tab, workbook rel, worksheet part, local defined-name indexes, and reachable sheet subgraph parts. |
 | `ws.title = 'Renamed' on loaded workbook` | `ws.title = 'Renamed' on modify=True workbook` | ✅ Supported |  | Modify-mode sheet title changes update workbook.xml and subsequent queued sheet mutations target the renamed tab. |
 | `wb.copy_worksheet(ws)` | `wb.copy_worksheet(ws)` | ✅ Supported |  | Diverges from openpyxl in 5 documented ways (always more preservation). |
 
@@ -54,7 +56,7 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 | `AreaChart / ScatterChart / BubbleChart / RadarChart` | `AreaChart / ScatterChart / BubbleChart / RadarChart` | ✅ Supported |  |  |
 | `BarChart3D / LineChart3D / PieChart3D / AreaChart3D` | `BarChart3D / LineChart3D / PieChart3D / AreaChart3D` | ✅ Supported |  |  |
 | `SurfaceChart / SurfaceChart3D / StockChart / ProjectedPieChart` | `SurfaceChart / SurfaceChart3D / StockChart / ProjectedPieChart` | ✅ Supported |  |  |
-| `ws.add_chart / remove_chart / replace_chart` | `ws.add_chart / remove_chart / replace_chart` | ✅ Supported |  | remove/replace shipped in v1.7. |
+| `ws.add_chart / remove_chart / replace_chart` | `ws.add_chart / remove_chart / replace_chart` | ✅ Supported |  | Covers pending charts plus source-loaded worksheet chart removal, replacement, and title edits in modify mode. |
 | `wb.create_chartsheet(...).add_chart(chart)` | `wb.create_chartsheet(...).add_chart(chart)` | ✅ Supported |  | Chartsheet authoring emits chartsheet, drawing, chart, rels, and content-type parts that openpyxl reloads; existing chartsheet tabs load back as workbook.chartsheets rather than worksheets. |
 | `bar + line on shared category axis with secondary value axis` | `bar + line on shared category axis with secondary value axis` | ✅ Supported |  | Combination charts ship as a multi-family `<plotArea>` (RFC-069 §6) for real Excel/LibreOffice rendering, plus per-family standalone shadow chartspaces parked at row 1048576 so openpyxl's reader exposes each family as a distinct `ws._charts` entry without the shadows visually overlapping the real combo. Secondary value axis (right side) honored when `line.y_axis.crosses='max'` and `line.y_axis.axId` is set. Closes G15. |
 | `data label + axis label rich-text runs` | `data label + axis label rich-text runs` | ✅ Supported | G10 | Data label `<c:txPr>` runs and axis-title rich text round-trip end-to-end (G10). |
@@ -131,7 +133,7 @@ This page is the public scoreboard for wolfxl's openpyxl-API compatibility. Each
 
 | openpyxl | wolfxl | Status | Gap | Notes |
 |---|---|---|---|---|
-| `wb._external_links + xl/externalLinks/* parts` | `wb._external_links + xl/externalLinks/* parts` | ✅ Supported |  | Inspection (target / sheet_names / cached_data), opaque modify-mode preservation when unchanged, and append/remove/edit authoring. |
+| `wb._external_links + xl/externalLinks/* parts` | `wb._external_links + xl/externalLinks/* parts` | ✅ Supported |  | Inspection (target / sheet_names / cached_data), opaque modify-mode preservation when unchanged, and append/remove/edit authoring. keep_links=False strips preserved source links, and file-like/bytes-backed xlsx reads expose the same collection. |
 | `append/remove/edit external workbook links` | `wb._external_links append/remove/update_target` | ✅ Supported |  | Authoring emits externalLink parts, workbook rels/references, content-types, and per-link rels. Cached data is preserved when provided but linked workbooks are not dereferenced. |
 
 ## VBA macros

--- a/python/wolfxl/__init__.py
+++ b/python/wolfxl/__init__.py
@@ -23,6 +23,7 @@ import os
 from typing import IO
 
 from wolfxl._cell import Cell
+from wolfxl.chartsheet import Chartsheet
 from wolfxl._external_links import ExternalFileLink, ExternalLink
 from wolfxl._rust import __version__, classify_format
 
@@ -44,6 +45,7 @@ __all__ = [
     "Alignment",
     "Border",
     "Cell",
+    "Chartsheet",
     "Color",
     "CopyOptions",
     "ExternalFileLink",

--- a/python/wolfxl/__init__.py
+++ b/python/wolfxl/__init__.py
@@ -167,6 +167,7 @@ def load_workbook(
         data=data,
         password=password,
         data_only=data_only,
+        keep_links=keep_links,
         permissive=permissive,
         modify=modify,
         read_only=read_only,

--- a/python/wolfxl/_chartsheets.py
+++ b/python/wolfxl/_chartsheets.py
@@ -173,6 +173,11 @@ def _rewrite_workbook_parts(
     if sheets_el is None:
         raise ValueError("workbook.xml has no <sheets> block")
 
+    old_order = [
+        sheet.attrib.get("name", "")
+        for sheet in list(sheets_el)
+        if sheet.attrib.get("name")
+    ]
     existing_by_name = {
         sheet.attrib.get("name"): sheet
         for sheet in list(sheets_el)
@@ -213,10 +218,35 @@ def _rewrite_workbook_parts(
             sheet.set(f"{{{REL_NS}}}id", chart_rid_by_name[name])
             sheets_el.append(sheet)
 
+    _remap_defined_name_local_sheet_ids(wb_root, old_order, list(wb._sheet_names))  # noqa: SLF001
     workbook_out = ET.tostring(wb_root, encoding="utf-8")
     ET.register_namespace("", PKG_REL_NS)
     rels_out = ET.tostring(rels_root, encoding="utf-8")
     return workbook_out, rels_out, rel_ids
+
+
+def _remap_defined_name_local_sheet_ids(
+    wb_root: ET.Element,
+    old_order: list[str],
+    new_order: list[str],
+) -> None:
+    defined_names_el = wb_root.find(f"{{{MAIN_NS}}}definedNames")
+    if defined_names_el is None:
+        return
+    new_index_by_name = {name: idx for idx, name in enumerate(new_order)}
+    for defined_name in defined_names_el.findall(f"{{{MAIN_NS}}}definedName"):
+        raw = defined_name.attrib.get("localSheetId")
+        if raw is None:
+            continue
+        try:
+            old_index = int(raw)
+        except ValueError:
+            continue
+        if old_index < 0 or old_index >= len(old_order):
+            continue
+        sheet_name = old_order[old_index]
+        if sheet_name in new_index_by_name:
+            defined_name.set("localSheetId", str(new_index_by_name[sheet_name]))
 
 
 def _max_sheet_id(sheets: Any) -> int:

--- a/python/wolfxl/_chartsheets.py
+++ b/python/wolfxl/_chartsheets.py
@@ -1,0 +1,295 @@
+"""Chartsheet authoring post-processor.
+
+The native writer emits ordinary worksheet parts. Chartsheets are workbook-tab
+parts that point at a drawing, which in turn points at a chart XML part. This
+module keeps that wiring in Python so the existing chart serializer can be
+reused without adding a second writer model.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import zipfile
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from wolfxl.chartsheet import Chartsheet
+
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+CT_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
+DRAWING_NS = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+C_NS = "http://schemas.openxmlformats.org/drawingml/2006/chart"
+
+RT_WORKSHEET = f"{REL_NS}/worksheet"
+RT_CHARTSHEET = f"{REL_NS}/chartsheet"
+RT_DRAWING = f"{REL_NS}/drawing"
+RT_CHART = f"{REL_NS}/chart"
+
+CT_CHARTSHEET = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml"
+)
+CT_DRAWING = "application/vnd.openxmlformats-officedocument.drawing+xml"
+CT_CHART = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml"
+
+
+def create_chartsheet(wb: Any, title: str | None = None, index: int | None = None) -> Chartsheet:
+    """Create a chartsheet tab in write or modify mode."""
+    if wb._rust_writer is None and wb._rust_patcher is None:  # noqa: SLF001
+        raise RuntimeError("create_chartsheet requires write or modify mode")
+    base = title or "Chart"
+    final = _unique_title(wb, base)
+    cs = Chartsheet(wb, final)
+    wb._chartsheets[final] = cs  # noqa: SLF001
+    if index is None:
+        wb._sheet_names.append(final)  # noqa: SLF001
+    else:
+        wb._sheet_names.insert(index, final)  # noqa: SLF001
+    wb._chartsheets_dirty = True  # noqa: SLF001
+    return cs
+
+
+def apply_chartsheets_to_xlsx(path: str, wb: Any) -> None:
+    """Rewrite ``path`` to include any authored chartsheets."""
+    chartsheets = [wb._chartsheets[name] for name in wb._sheet_names if name in wb._chartsheets]  # noqa: SLF001
+    if not chartsheets:
+        return
+
+    with zipfile.ZipFile(path, "r") as src:
+        workbook_xml = src.read("xl/workbook.xml")
+        workbook_rels_xml = src.read("xl/_rels/workbook.xml.rels")
+        content_types_xml = src.read("[Content_Types].xml")
+        names = src.namelist()
+
+    next_chartsheet = _next_index(names, r"^xl/chartsheets/sheet(\d+)\.xml$")
+    next_drawing = _next_index(names, r"^xl/drawings/drawing(\d+)\.xml$")
+    next_chart = _next_index(names, r"^xl/charts/chart(\d+)\.xml$")
+    workbook_xml_out, workbook_rels_out, rel_ids = _rewrite_workbook_parts(
+        workbook_xml,
+        workbook_rels_xml,
+        wb,
+        chartsheets,
+        next_chartsheet,
+    )
+
+    generated: dict[str, bytes] = {
+        "xl/workbook.xml": workbook_xml_out,
+        "xl/_rels/workbook.xml.rels": workbook_rels_out,
+    }
+    content_type_overrides: dict[str, str] = {}
+
+    for offset, cs in enumerate(chartsheets):
+        chartsheet_n = next_chartsheet + offset
+        drawing_n = next_drawing + offset
+        chart_n = next_chart + offset
+        has_chart = bool(cs._charts)
+        generated[f"xl/chartsheets/sheet{chartsheet_n}.xml"] = _render_chartsheet_xml(
+            has_drawing=has_chart
+        )
+        content_type_overrides[f"/xl/chartsheets/sheet{chartsheet_n}.xml"] = CT_CHARTSHEET
+        if has_chart:
+            generated[f"xl/chartsheets/_rels/sheet{chartsheet_n}.xml.rels"] = (
+                _render_single_rel_xml(RT_DRAWING, f"/xl/drawings/drawing{drawing_n}.xml")
+            )
+            generated[f"xl/drawings/drawing{drawing_n}.xml"] = _render_chartsheet_drawing_xml()
+            generated[f"xl/drawings/_rels/drawing{drawing_n}.xml.rels"] = _render_single_rel_xml(
+                RT_CHART,
+                f"/xl/charts/chart{chart_n}.xml",
+            )
+            generated[f"xl/charts/chart{chart_n}.xml"] = _serialize_chart(cs)
+            content_type_overrides[f"/xl/drawings/drawing{drawing_n}.xml"] = CT_DRAWING
+            content_type_overrides[f"/xl/charts/chart{chart_n}.xml"] = CT_CHART
+        else:
+            generated[f"xl/chartsheets/_rels/sheet{chartsheet_n}.xml.rels"] = (
+                _render_empty_rels_xml()
+            )
+        # Keep the variable used so a mismatch between workbook rel ordering and
+        # generated parts is caught by static checkers.
+        assert rel_ids[offset]
+
+    generated["[Content_Types].xml"] = _rewrite_content_types(
+        content_types_xml,
+        content_type_overrides,
+    )
+
+    fd, tmp_name = tempfile.mkstemp(prefix="wolfxl-chartsheets-", suffix=".xlsx")
+    os.close(fd)
+    try:
+        with zipfile.ZipFile(path, "r") as src, zipfile.ZipFile(
+            tmp_name, "w", zipfile.ZIP_DEFLATED
+        ) as dst:
+            for info in src.infolist():
+                if info.filename in generated:
+                    continue
+                with src.open(info, "r") as handle:
+                    dst.writestr(info, handle.read())
+            for name in sorted(generated):
+                dst.writestr(name, generated[name])
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+    wb._chartsheets_dirty = False  # noqa: SLF001
+
+
+def _unique_title(wb: Any, base: str) -> str:
+    existing = set(wb._sheet_names)  # noqa: SLF001
+    if base not in existing:
+        return base
+    i = 1
+    while f"{base}{i}" in existing:
+        i += 1
+    return f"{base}{i}"
+
+
+def _next_index(names: list[str], pattern: str) -> int:
+    rx = re.compile(pattern)
+    seen = [int(m.group(1)) for name in names if (m := rx.match(name))]
+    return max(seen, default=0) + 1
+
+
+def _rewrite_workbook_parts(
+    workbook_xml: bytes,
+    workbook_rels_xml: bytes,
+    wb: Any,
+    chartsheets: list[Chartsheet],
+    first_chartsheet_n: int,
+) -> tuple[bytes, bytes, list[str]]:
+    ET.register_namespace("", MAIN_NS)
+    ET.register_namespace("r", REL_NS)
+    wb_root = ET.fromstring(workbook_xml)
+    rels_root = ET.fromstring(workbook_rels_xml)
+    sheets_el = wb_root.find(f"{{{MAIN_NS}}}sheets")
+    if sheets_el is None:
+        raise ValueError("workbook.xml has no <sheets> block")
+
+    existing_by_name = {
+        sheet.attrib.get("name"): sheet
+        for sheet in list(sheets_el)
+        if sheet.attrib.get("name") not in wb._chartsheets  # noqa: SLF001
+    }
+    existing_rel_ids = [
+        rel.attrib.get("Id", "")
+        for rel in rels_root.findall(f"{{{PKG_REL_NS}}}Relationship")
+    ]
+    next_rid_num = _next_rid_number(existing_rel_ids)
+
+    rel_ids: list[str] = []
+    chartsheet_by_name = {cs.title: cs for cs in chartsheets}
+    for offset, cs in enumerate(chartsheets):
+        rid = f"rId{next_rid_num + offset}"
+        rel_ids.append(rid)
+        rel = ET.Element(f"{{{PKG_REL_NS}}}Relationship")
+        rel.set("Id", rid)
+        rel.set("Type", RT_CHARTSHEET)
+        rel.set("Target", f"/xl/chartsheets/sheet{first_chartsheet_n + offset}.xml")
+        rels_root.append(rel)
+
+    sheets_el.clear()
+    max_sheet_id = _max_sheet_id(existing_by_name.values())
+    chart_rid_by_name = {cs.title: rid for cs, rid in zip(chartsheets, rel_ids)}
+    chart_sheet_id_by_name = {
+        cs.title: str(max_sheet_id + idx + 1) for idx, cs in enumerate(chartsheets)
+    }
+    for name in wb._sheet_names:  # noqa: SLF001
+        if name in existing_by_name:
+            sheets_el.append(existing_by_name[name])
+        elif name in chartsheet_by_name:
+            sheet = ET.Element(f"{{{MAIN_NS}}}sheet")
+            sheet.set("name", name)
+            sheet.set("sheetId", chart_sheet_id_by_name[name])
+            if chartsheet_by_name[name].sheet_state != "visible":
+                sheet.set("state", chartsheet_by_name[name].sheet_state)
+            sheet.set(f"{{{REL_NS}}}id", chart_rid_by_name[name])
+            sheets_el.append(sheet)
+
+    workbook_out = ET.tostring(wb_root, encoding="utf-8")
+    ET.register_namespace("", PKG_REL_NS)
+    rels_out = ET.tostring(rels_root, encoding="utf-8")
+    return workbook_out, rels_out, rel_ids
+
+
+def _max_sheet_id(sheets: Any) -> int:
+    values = []
+    for sheet in sheets:
+        try:
+            values.append(int(sheet.attrib.get("sheetId", "0")))
+        except ValueError:
+            pass
+    return max(values, default=0)
+
+
+def _next_rid_number(ids: list[str]) -> int:
+    nums = []
+    for rid in ids:
+        if rid.startswith("rId"):
+            try:
+                nums.append(int(rid[3:]))
+            except ValueError:
+                pass
+    return max(nums, default=0) + 1
+
+
+def _serialize_chart(cs: Chartsheet) -> bytes:
+    from wolfxl._rust import serialize_chart_dict
+
+    chart = cs._charts[0]
+    return bytes(serialize_chart_dict(chart.to_rust_dict(), "A1"))
+
+
+def _render_chartsheet_xml(*, has_drawing: bool = True) -> bytes:
+    drawing = '<drawing r:id="rId1"/>' if has_drawing else ""
+    xml = (
+        f'<chartsheet xmlns="{MAIN_NS}" xmlns:r="{REL_NS}">'
+        '<sheetViews><sheetView workbookViewId="0" zoomToFit="1"/></sheetViews>'
+        f"{drawing}"
+        "</chartsheet>"
+    )
+    return xml.encode("utf-8")
+
+
+def _render_chartsheet_drawing_xml() -> bytes:
+    xml = (
+        f'<wsDr xmlns="{DRAWING_NS}" xmlns:a="{A_NS}" xmlns:c="{C_NS}" xmlns:r="{REL_NS}">'
+        '<absoluteAnchor><pos x="0" y="0"/><ext cx="0" cy="0"/>'
+        '<graphicFrame><nvGraphicFramePr><cNvPr id="1" name="Chart 1"/>'
+        "<cNvGraphicFramePr/></nvGraphicFramePr><xfrm/>"
+        f'<a:graphic><a:graphicData uri="{C_NS}"><c:chart r:id="rId1"/>'
+        "</a:graphicData></a:graphic></graphicFrame><clientData/></absoluteAnchor>"
+        "</wsDr>"
+    )
+    return xml.encode("utf-8")
+
+
+def _render_single_rel_xml(rel_type: str, target: str) -> bytes:
+    xml = (
+        f'<Relationships xmlns="{PKG_REL_NS}">'
+        f'<Relationship Id="rId1" Type="{rel_type}" Target="{target}"/>'
+        "</Relationships>"
+    )
+    return xml.encode("utf-8")
+
+
+def _render_empty_rels_xml() -> bytes:
+    return f'<Relationships xmlns="{PKG_REL_NS}"/>'.encode("utf-8")
+
+
+def _rewrite_content_types(content_types_xml: bytes, overrides: dict[str, str]) -> bytes:
+    ET.register_namespace("", CT_NS)
+    root = ET.fromstring(content_types_xml)
+    existing = {
+        child.attrib.get("PartName"): child
+        for child in root.findall(f"{{{CT_NS}}}Override")
+    }
+    for part_name, content_type in overrides.items():
+        node = existing.get(part_name)
+        if node is None:
+            node = ET.Element(f"{{{CT_NS}}}Override")
+            node.set("PartName", part_name)
+            root.append(node)
+        node.set("ContentType", content_type)
+    return ET.tostring(root, encoding="utf-8")

--- a/python/wolfxl/_chartsheets.py
+++ b/python/wolfxl/_chartsheets.py
@@ -44,6 +44,7 @@ def create_chartsheet(wb: Any, title: str | None = None, index: int | None = Non
     base = title or "Chart"
     final = _unique_title(wb, base)
     cs = Chartsheet(wb, final)
+    cs._source_chartsheet = False
     wb._chartsheets[final] = cs  # noqa: SLF001
     if index is None:
         wb._sheet_names.append(final)  # noqa: SLF001
@@ -55,7 +56,12 @@ def create_chartsheet(wb: Any, title: str | None = None, index: int | None = Non
 
 def apply_chartsheets_to_xlsx(path: str, wb: Any) -> None:
     """Rewrite ``path`` to include any authored chartsheets."""
-    chartsheets = [wb._chartsheets[name] for name in wb._sheet_names if name in wb._chartsheets]  # noqa: SLF001
+    chartsheets = [
+        wb._chartsheets[name]  # noqa: SLF001
+        for name in wb._sheet_names  # noqa: SLF001
+        if name in wb._chartsheets  # noqa: SLF001
+        and not getattr(wb._chartsheets[name], "_source_chartsheet", False)  # noqa: SLF001
+    ]
     if not chartsheets:
         return
 
@@ -170,7 +176,7 @@ def _rewrite_workbook_parts(
     existing_by_name = {
         sheet.attrib.get("name"): sheet
         for sheet in list(sheets_el)
-        if sheet.attrib.get("name") not in wb._chartsheets  # noqa: SLF001
+        if sheet.attrib.get("name") not in {cs.title for cs in chartsheets}
     }
     existing_rel_ids = [
         rel.attrib.get("Id", "")

--- a/python/wolfxl/_external_links.py
+++ b/python/wolfxl/_external_links.py
@@ -221,6 +221,17 @@ def load_external_links(source_path: str | None) -> ExternalLinkCollection:
         return ExternalLinkCollection()
 
 
+def load_external_links_from_bytes(data: bytes | bytearray | memoryview) -> ExternalLinkCollection:
+    """Load external-link parts from an in-memory xlsx blob."""
+    import io
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(bytes(data)), "r") as zf:
+            return ExternalLinkCollection(_load_from_zip(zf))
+    except (zipfile.BadZipFile, KeyError, OSError):
+        return ExternalLinkCollection()
+
+
 def apply_authoring_to_xlsx(path: str, links: ExternalLinkCollection) -> None:
     """Rewrite workbook external-link parts to match ``links``."""
     if not links.dirty:

--- a/python/wolfxl/_source_charts.py
+++ b/python/wolfxl/_source_charts.py
@@ -1,0 +1,220 @@
+"""Surgical rewrites for charts that came from the source workbook."""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import tempfile
+import zipfile
+from typing import Any
+from xml.etree import ElementTree as ET
+
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+DRAWING_REL = f"{REL_NS}/drawing"
+CHART_REL = f"{REL_NS}/chart"
+CHART_CT = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml"
+
+ET.register_namespace("xdr", "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing")
+ET.register_namespace("a", "http://schemas.openxmlformats.org/drawingml/2006/main")
+ET.register_namespace("c", "http://schemas.openxmlformats.org/drawingml/2006/chart")
+ET.register_namespace("r", REL_NS)
+
+
+def source_chart_refs(path: str | None, sheet_title: str) -> list[dict[str, str]]:
+    """Return source chart OOXML identities for ``sheet_title`` in reader order."""
+    if not path:
+        return []
+    try:
+        with zipfile.ZipFile(path, "r") as zf:
+            sheet_path = _sheet_path_for_title(zf, sheet_title)
+            if not sheet_path:
+                return []
+            return _chart_refs_for_sheet(zf, sheet_path)
+    except (OSError, KeyError, zipfile.BadZipFile, ET.ParseError):
+        return []
+
+
+def apply_source_chart_authoring_to_xlsx(path: str, ops: list[dict[str, Any]]) -> None:
+    """Apply source-chart remove/replace operations to ``path`` in-place."""
+    if not ops:
+        return
+
+    generated: dict[str, bytes] = {}
+    deletes: set[str] = set()
+    remove_chart_paths: set[str] = set()
+
+    with zipfile.ZipFile(path, "r") as src:
+        content_types = ET.fromstring(src.read("[Content_Types].xml"))
+
+        for op in ops:
+            meta = op["meta"]
+            chart_path = meta["chart_path"]
+            if op["op"] in {"replace", "title"}:
+                generated[chart_path] = op["chart_xml"]
+                continue
+
+            if op["op"] != "remove":
+                continue
+
+            drawing_path = meta["drawing_path"]
+            drawing_rels_path = meta["drawing_rels_path"]
+            chart_rid = meta["chart_rid"]
+
+            drawing_xml = generated.get(drawing_path) or src.read(drawing_path)
+            generated[drawing_path] = _remove_chart_anchor(drawing_xml, chart_rid)
+
+            drawing_rels = generated.get(drawing_rels_path) or src.read(drawing_rels_path)
+            generated[drawing_rels_path] = _remove_rel_by_id(drawing_rels, chart_rid)
+
+            deletes.add(chart_path)
+            remove_chart_paths.add(chart_path)
+
+        if remove_chart_paths:
+            _remove_content_type_overrides(content_types, remove_chart_paths)
+            generated["[Content_Types].xml"] = ET.tostring(
+                content_types, encoding="utf-8", xml_declaration=True
+            )
+
+    fd, tmp_name = tempfile.mkstemp(prefix="wolfxl-source-charts-", suffix=".xlsx")
+    os.close(fd)
+    try:
+        with zipfile.ZipFile(path, "r") as src, zipfile.ZipFile(
+            tmp_name, "w", zipfile.ZIP_DEFLATED
+        ) as dst:
+            for info in src.infolist():
+                name = info.filename
+                if name in deletes or name in generated:
+                    continue
+                with src.open(info, "r") as handle:
+                    dst.writestr(info, handle.read())
+            for name in sorted(generated):
+                dst.writestr(name, generated[name])
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _sheet_path_for_title(zf: zipfile.ZipFile, sheet_title: str) -> str | None:
+    workbook = ET.fromstring(zf.read("xl/workbook.xml"))
+    rels = _parse_rels(zf.read("xl/_rels/workbook.xml.rels"))
+    for sheet in workbook.iter():
+        if _local(sheet.tag) != "sheet" or sheet.attrib.get("name") != sheet_title:
+            continue
+        rid = _rel_id(sheet.attrib)
+        if not rid or rid not in rels:
+            return None
+        return _resolve_target("xl/workbook.xml", rels[rid]["Target"])
+    return None
+
+
+def _chart_refs_for_sheet(zf: zipfile.ZipFile, sheet_path: str) -> list[dict[str, str]]:
+    rels_path = _rels_path_for(sheet_path)
+    try:
+        sheet_rels = _parse_rels(zf.read(rels_path))
+    except KeyError:
+        return []
+
+    refs: list[dict[str, str]] = []
+    for rel in sheet_rels.values():
+        if rel.get("Type") != DRAWING_REL:
+            continue
+        drawing_path = _resolve_target(sheet_path, rel["Target"])
+        drawing_rels_path = _rels_path_for(drawing_path)
+        try:
+            drawing_xml = zf.read(drawing_path)
+            drawing_rels = _parse_rels(zf.read(drawing_rels_path))
+        except KeyError:
+            continue
+        chart_rids = _chart_rids_in_drawing_order(drawing_xml)
+        for chart_rid in chart_rids:
+            chart_rel = drawing_rels.get(chart_rid)
+            if not chart_rel or chart_rel.get("Type") != CHART_REL:
+                continue
+            refs.append(
+                {
+                    "sheet_path": sheet_path,
+                    "drawing_path": drawing_path,
+                    "drawing_rels_path": drawing_rels_path,
+                    "chart_path": _resolve_target(drawing_path, chart_rel["Target"]),
+                    "chart_rid": chart_rid,
+                }
+            )
+    return refs
+
+
+def _chart_rids_in_drawing_order(drawing_xml: bytes) -> list[str]:
+    root = ET.fromstring(drawing_xml)
+    rids: list[str] = []
+    for anchor in list(root):
+        if _local(anchor.tag) not in {"oneCellAnchor", "twoCellAnchor", "absoluteAnchor"}:
+            continue
+        for child in anchor.iter():
+            if _local(child.tag) == "chart":
+                rid = _rel_id(child.attrib)
+                if rid:
+                    rids.append(rid)
+                break
+    return rids
+
+
+def _remove_chart_anchor(drawing_xml: bytes, chart_rid: str) -> bytes:
+    root = ET.fromstring(drawing_xml)
+    for anchor in list(root):
+        if _local(anchor.tag) not in {"oneCellAnchor", "twoCellAnchor", "absoluteAnchor"}:
+            continue
+        if any(_local(node.tag) == "chart" and _rel_id(node.attrib) == chart_rid for node in anchor.iter()):
+            root.remove(anchor)
+            break
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _remove_rel_by_id(rels_xml: bytes, rid: str) -> bytes:
+    root = ET.fromstring(rels_xml)
+    for rel in list(root):
+        if _local(rel.tag) == "Relationship" and rel.attrib.get("Id") == rid:
+            root.remove(rel)
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _remove_content_type_overrides(root: ET.Element, chart_paths: set[str]) -> None:
+    part_names = {f"/{path}" for path in chart_paths}
+    for child in list(root):
+        if (
+            _local(child.tag) == "Override"
+            and child.attrib.get("PartName") in part_names
+            and child.attrib.get("ContentType") == CHART_CT
+        ):
+            root.remove(child)
+
+
+def _parse_rels(xml: bytes) -> dict[str, dict[str, str]]:
+    root = ET.fromstring(xml)
+    out: dict[str, dict[str, str]] = {}
+    for rel in root:
+        if _local(rel.tag) == "Relationship" and rel.attrib.get("Id"):
+            out[str(rel.attrib["Id"])] = dict(rel.attrib)
+    return out
+
+
+def _rel_id(attrs: dict[str, str]) -> str | None:
+    for key, value in attrs.items():
+        if key == f"{{{REL_NS}}}id" or key.endswith("}id") or key == "r:id":
+            return value
+    return None
+
+
+def _rels_path_for(part_path: str) -> str:
+    parent, name = posixpath.split(part_path)
+    return posixpath.join(parent, "_rels", f"{name}.rels")
+
+
+def _resolve_target(base_part: str, target: str) -> str:
+    if target.startswith("/"):
+        return target.lstrip("/")
+    return posixpath.normpath(posixpath.join(posixpath.dirname(base_part), target))
+
+
+def _local(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]

--- a/python/wolfxl/_workbook.py
+++ b/python/wolfxl/_workbook.py
@@ -274,13 +274,14 @@ class Workbook:
     @property
     def worksheets(self) -> list[Worksheet]:
         """List of Worksheet objects in sheet order — openpyxl alias."""
-        return [self._sheets[name] for name in self._sheet_names]
+        return [self._sheets[name] for name in self._sheet_names if name in self._sheets]
 
     @property
     def active(self) -> Worksheet | None:
         """Return the first sheet, or None if no sheets exist."""
-        if self._sheet_names:
-            return self._sheets[self._sheet_names[0]]
+        for name in self._sheet_names:
+            if name in self._sheets:
+                return self._sheets[name]
         return None
 
     @property
@@ -387,10 +388,11 @@ class Workbook:
     def chartsheets(self) -> list[Any]:
         """Return chart sheets in this workbook.
 
-        WolfXL preserves chart sheets when possible, but does not expose
-        Python chart-sheet objects through this compatibility property yet.
+        Write/modify-mode chartsheets created through
+        :meth:`create_chartsheet` are returned in tab order.
         """
-        return []
+        chartsheets = getattr(self, "_chartsheets", {})
+        return [chartsheets[name] for name in self._sheet_names if name in chartsheets]
 
     @property
     def epoch(self) -> Any:
@@ -543,14 +545,17 @@ class Workbook:
         return self._persons_registry
 
     def __getitem__(self, name: str) -> Worksheet:
-        """Return a worksheet by title."""
-        if name not in self._sheets:
-            raise KeyError(f"Worksheet '{name}' does not exist")
-        return self._sheets[name]
+        """Return a worksheet or chartsheet by title."""
+        if name in self._sheets:
+            return self._sheets[name]
+        chartsheets = getattr(self, "_chartsheets", {})
+        if name in chartsheets:
+            return chartsheets[name]
+        raise KeyError(f"Worksheet '{name}' does not exist")
 
     def __contains__(self, name: str) -> bool:
         """Return whether the workbook contains a sheet named ``name``."""
-        return name in self._sheets
+        return name in self._sheets or name in getattr(self, "_chartsheets", {})
 
     def __iter__(self):  # type: ignore[no-untyped-def]
         """Iterate worksheet titles in tab order."""
@@ -686,12 +691,10 @@ class Workbook:
         )
 
     def create_chartsheet(self, title: str | None = None, index: int | None = None) -> Any:
-        """Raise clearly for chart-sheet creation, which WolfXL does not write yet."""
-        raise NotImplementedError(
-            "Workbook.create_chartsheet is not yet supported by wolfxl. "
-            "Existing chartsheets are preserved where possible, but creating "
-            "new chart-sheet parts requires chart-sheet writer support."
-        )
+        """Create a chartsheet tab."""
+        from wolfxl import _chartsheets
+
+        return _chartsheets.create_chartsheet(self, title=title, index=index)
 
     @property
     def workbook_properties(self) -> Any:
@@ -946,9 +949,8 @@ class Workbook:
         :class:`wolfxl.drawing.image.Image` is converted to the flat
         dict shape and routed to ``XlsxPatcher.queue_image_add``.
 
-        Sheets that already have a drawing rel will surface
-        ``NotImplementedError`` from the patcher at save time —
-        appending to an existing drawing is a v1.5 follow-up.
+        Sheets that already have a drawing rel are merged into the existing
+        drawing part so images and charts can share one drawing.
         """
         _workbook_patcher_flush.flush_pending_images_to_patcher(self)
 

--- a/python/wolfxl/_workbook.py
+++ b/python/wolfxl/_workbook.py
@@ -74,7 +74,7 @@ class Workbook:
         # G20: streaming write-only mode. When set, create_sheet returns
         # WriteOnlyWorksheet instances and the default sheet is skipped.
         self._write_only: bool = bool(write_only)
-        # Re-entry guard for openpyxl-shape consumed-on-save semantic.
+        # Re-entry guard for openpyxl-shape write-only consumed-on-save semantic.
         self._saved: bool = False
         if self._write_only:
             self._sheet_names: list[str] = []

--- a/python/wolfxl/_workbook.py
+++ b/python/wolfxl/_workbook.py
@@ -797,18 +797,18 @@ class Workbook:
     # Write-mode operations
     # ------------------------------------------------------------------
 
-    def create_sheet(self, title: str = "Sheet", index: int | None = None) -> Worksheet:
+    def create_sheet(self, title: str | None = None, index: int | None = None) -> Worksheet:
         """Create and append a worksheet.
 
         Args:
-            title: Unique worksheet title.
+            title: Worksheet title. When omitted, empty, or already present,
+                WolfXL mirrors openpyxl by generating the next unique title.
 
         Returns:
             The newly created :class:`Worksheet`.
 
         Raises:
             RuntimeError: If the workbook is not in write mode.
-            ValueError: If ``title`` already exists.
         """
         return _workbook_sheets.create_sheet(self, title, index)
 

--- a/python/wolfxl/_workbook.py
+++ b/python/wolfxl/_workbook.py
@@ -370,12 +370,22 @@ class Workbook:
 
         from wolfxl import _external_links as _el
 
+        if not getattr(self, "_keep_links", True):
+            cached = _el.ExternalLinkCollection()
+            self._external_links_cache = cached
+            return cached
+
         source_path = getattr(self, "_source_path", None)
+        source_bytes = getattr(self, "_source_bytes", None)
+        if source_path:
+            cached = _el.load_external_links(source_path)
+        elif source_bytes:
+            cached = _el.load_external_links_from_bytes(source_bytes)
         # Write mode: no source ZIP exists yet, return an empty list.
-        if self._rust_writer is not None or not source_path:
+        elif self._rust_writer is not None:
             cached = _el.ExternalLinkCollection()
         else:
-            cached = _el.load_external_links(source_path)
+            cached = _el.ExternalLinkCollection()
         self._external_links_cache = cached
         return cached
 
@@ -787,7 +797,7 @@ class Workbook:
     # Write-mode operations
     # ------------------------------------------------------------------
 
-    def create_sheet(self, title: str) -> Worksheet:
+    def create_sheet(self, title: str = "Sheet", index: int | None = None) -> Worksheet:
         """Create and append a worksheet.
 
         Args:
@@ -800,7 +810,7 @@ class Workbook:
             RuntimeError: If the workbook is not in write mode.
             ValueError: If ``title`` already exists.
         """
-        return _workbook_sheets.create_sheet(self, title)
+        return _workbook_sheets.create_sheet(self, title, index)
 
     def copy_worksheet(
         self, source: Worksheet, *, name: str | None = None

--- a/python/wolfxl/_workbook_save.py
+++ b/python/wolfxl/_workbook_save.py
@@ -78,6 +78,7 @@ def save_write_only_mode(wb: Any, filename: str) -> None:
     wb._flush_workbook_writes()  # noqa: SLF001
     wb._rust_writer.finalize_streaming_sheets()  # noqa: SLF001
     wb._rust_writer.save(filename)  # noqa: SLF001
+    flush_chartsheets_authoring(wb, filename)
 
 
 def save_modify_mode(wb: Any, filename: str) -> None:
@@ -146,6 +147,7 @@ def save_modify_mode(wb: Any, filename: str) -> None:
         wb._rust_patcher.save(filename)  # noqa: SLF001
     flush_pivot_layout_authoring(wb, filename)
     flush_external_links_authoring(wb, filename)
+    flush_chartsheets_authoring(wb, filename)
 
 
 def save_write_mode(wb: Any, filename: str) -> None:
@@ -167,10 +169,12 @@ def save_write_mode(wb: Any, filename: str) -> None:
             ws._flush()  # noqa: SLF001
         wb._rust_writer.save(filename)  # noqa: SLF001
         flush_external_links_authoring(wb, filename)
+        flush_chartsheets_authoring(wb, filename)
         return
 
     _save_write_mode_with_pivots(wb, filename)
     flush_external_links_authoring(wb, filename)
+    flush_chartsheets_authoring(wb, filename)
 
 
 def flush_external_links_authoring(wb: Any, filename: str) -> None:
@@ -180,6 +184,14 @@ def flush_external_links_authoring(wb: Any, filename: str) -> None:
     from wolfxl import _external_links as _el
 
     _el.apply_authoring_to_xlsx(filename, links)
+
+
+def flush_chartsheets_authoring(wb: Any, filename: str) -> None:
+    if not getattr(wb, "_chartsheets", None):
+        return
+    from wolfxl import _chartsheets
+
+    _chartsheets.apply_chartsheets_to_xlsx(filename, wb)
 
 
 def flush_pivot_layout_authoring(wb: Any, filename: str) -> None:

--- a/python/wolfxl/_workbook_save.py
+++ b/python/wolfxl/_workbook_save.py
@@ -147,6 +147,7 @@ def save_modify_mode(wb: Any, filename: str) -> None:
         wb._rust_patcher.save(filename)  # noqa: SLF001
     flush_pivot_layout_authoring(wb, filename)
     flush_external_links_authoring(wb, filename)
+    flush_source_chart_authoring(wb, filename)
     flush_chartsheets_authoring(wb, filename)
 
 
@@ -179,11 +180,17 @@ def save_write_mode(wb: Any, filename: str) -> None:
 
 def flush_external_links_authoring(wb: Any, filename: str) -> None:
     links = getattr(wb, "_external_links_cache", None)
-    if links is None or not getattr(links, "dirty", False):
+    strip_links = bool(getattr(wb, "_strip_external_links_on_save", False))
+    if links is None and strip_links:
+        links = wb._external_links  # noqa: SLF001
+    if links is None or (not getattr(links, "dirty", False) and not strip_links):
         return
     from wolfxl import _external_links as _el
 
+    if strip_links:
+        links._mark_dirty()  # noqa: SLF001
     _el.apply_authoring_to_xlsx(filename, links)
+    wb._strip_external_links_on_save = False  # noqa: SLF001
 
 
 def flush_chartsheets_authoring(wb: Any, filename: str) -> None:
@@ -195,6 +202,63 @@ def flush_chartsheets_authoring(wb: Any, filename: str) -> None:
     from wolfxl import _chartsheets
 
     _chartsheets.apply_chartsheets_to_xlsx(filename, wb)
+
+
+def flush_source_chart_authoring(wb: Any, filename: str) -> None:
+    ops = list(getattr(wb, "_pending_source_chart_ops", []))
+    touched = {
+        op.get("meta", {}).get("chart_path")
+        for op in ops
+        if isinstance(op.get("meta"), dict)
+    }
+    for ws in getattr(wb, "_sheets", {}).values():
+        for chart in getattr(ws, "_charts_cache", None) or []:
+            meta = getattr(chart, "_wolfxl_source_chart", None)
+            if not meta or meta.get("chart_path") in touched:
+                continue
+            original_title = getattr(chart, "_wolfxl_source_title", None)
+            current_title = _source_chart_title_signature(chart)
+            if current_title != original_title:
+                ops.append({"op": "title", "meta": meta, "chart": chart})
+                touched.add(meta.get("chart_path"))
+
+    if not ops:
+        return
+
+    from wolfxl import _source_charts
+
+    materialized = []
+    for op in ops:
+        if op["op"] in {"replace", "title"}:
+            op = dict(op)
+            op["chart_xml"] = _serialize_chart_xml(op["chart"])
+        materialized.append(op)
+    _source_charts.apply_source_chart_authoring_to_xlsx(filename, materialized)
+    wb._pending_source_chart_ops.clear()  # noqa: SLF001
+
+
+def _serialize_chart_xml(chart: Any) -> bytes:
+    from wolfxl._rust import serialize_chart_dict  # type: ignore[attr-defined]
+
+    original_anchor = getattr(chart, "_anchor", None)
+    chart._anchor = "E15"  # noqa: SLF001
+    try:
+        return serialize_chart_dict(chart.to_rust_dict(), "E15")
+    finally:
+        chart._anchor = original_anchor  # noqa: SLF001
+
+
+def _source_chart_title_signature(chart: Any) -> Any:
+    title = getattr(chart, "title", None)
+    if title is None:
+        return None
+    to_dict = getattr(title, "to_dict", None)
+    if to_dict is not None:
+        try:
+            return to_dict()
+        except Exception:
+            pass
+    return str(title)
 
 
 def flush_pivot_layout_authoring(wb: Any, filename: str) -> None:

--- a/python/wolfxl/_workbook_save.py
+++ b/python/wolfxl/_workbook_save.py
@@ -187,7 +187,10 @@ def flush_external_links_authoring(wb: Any, filename: str) -> None:
 
 
 def flush_chartsheets_authoring(wb: Any, filename: str) -> None:
-    if not getattr(wb, "_chartsheets", None):
+    chartsheets = getattr(wb, "_chartsheets", None)
+    if not chartsheets or not any(
+        not getattr(cs, "_source_chartsheet", False) for cs in chartsheets.values()
+    ):
         return
     from wolfxl import _chartsheets
 

--- a/python/wolfxl/_workbook_sheets.py
+++ b/python/wolfxl/_workbook_sheets.py
@@ -8,7 +8,7 @@ from wolfxl._worksheet import Worksheet
 
 
 def remove_sheet(wb: Any, worksheet: Worksheet) -> None:
-    """Remove ``worksheet`` from a write-mode workbook.
+    """Remove ``worksheet`` from a write or modify-mode workbook.
 
     Args:
         wb: Workbook-like object carrying writer and sheet state.
@@ -18,20 +18,23 @@ def remove_sheet(wb: Any, worksheet: Worksheet) -> None:
         RuntimeError: If ``wb`` is not in write mode.
         ValueError: If ``worksheet`` is not registered on ``wb``.
     """
-    if wb._rust_writer is None:  # noqa: SLF001
-        raise RuntimeError("remove requires write mode")
+    if wb._rust_writer is None and wb._rust_patcher is None:  # noqa: SLF001
+        raise RuntimeError("remove requires write mode or modify mode")
     if worksheet.title not in wb._sheets:  # noqa: SLF001
         raise ValueError(f"Worksheet '{worksheet.title}' is not in this workbook")
     title = worksheet.title
     wb._sheet_names.remove(title)  # noqa: SLF001
     wb._sheets.pop(title)  # noqa: SLF001
+    if wb._rust_patcher is not None:  # noqa: SLF001
+        wb._rust_patcher.queue_sheet_delete(title)  # noqa: SLF001
+        return
     remove_fn = getattr(wb._rust_writer, "remove_sheet", None)  # noqa: SLF001
     if remove_fn is not None:
         remove_fn(title)
 
 
-def create_sheet(wb: Any, title: str) -> Worksheet:
-    """Create and append a worksheet in write mode.
+def create_sheet(wb: Any, title: str, index: int | None = None) -> Worksheet:
+    """Create and append a worksheet in write or modify mode.
 
     Args:
         wb: Workbook-like object carrying writer and sheet state.
@@ -44,10 +47,17 @@ def create_sheet(wb: Any, title: str) -> Worksheet:
         RuntimeError: If ``wb`` is not in write mode.
         ValueError: If ``title`` is already used.
     """
-    if wb._rust_writer is None:  # noqa: SLF001
-        raise RuntimeError("create_sheet requires write mode")
     if title in wb._sheets or title in getattr(wb, "_chartsheets", {}):  # noqa: SLF001
         raise ValueError(f"Sheet '{title}' already exists")
+    insert_at = _normalize_insert_index(wb, index)
+    if wb._rust_patcher is not None:  # noqa: SLF001
+        wb._rust_patcher.queue_sheet_create(title, insert_at)  # noqa: SLF001
+        wb._sheet_names.insert(insert_at, title)  # noqa: SLF001
+        ws = Worksheet(wb, title)
+        wb._sheets[title] = ws  # noqa: SLF001
+        return ws
+    if wb._rust_writer is None:  # noqa: SLF001
+        raise RuntimeError("create_sheet requires write or modify mode")
     # G20: streaming write-only mode dispatches to a different sheet
     # type — the eager Worksheet is materialisation-heavy, while
     # WriteOnlyWorksheet streams rows straight to a temp file.
@@ -55,15 +65,36 @@ def create_sheet(wb: Any, title: str) -> Worksheet:
         from wolfxl._worksheet_write_only import WriteOnlyWorksheet
 
         wb._rust_writer.add_sheet(title)  # noqa: SLF001
-        wb._sheet_names.append(title)  # noqa: SLF001
+        wb._sheet_names.insert(insert_at, title)  # noqa: SLF001
         ws = WriteOnlyWorksheet(wb, title)
         wb._sheets[title] = ws  # noqa: SLF001
+        _move_new_writer_sheet_to_index(wb, title, insert_at)
         return ws  # type: ignore[return-value]
     wb._rust_writer.add_sheet(title)  # noqa: SLF001
-    wb._sheet_names.append(title)  # noqa: SLF001
+    wb._sheet_names.insert(insert_at, title)  # noqa: SLF001
     ws = Worksheet(wb, title)
     wb._sheets[title] = ws  # noqa: SLF001
+    _move_new_writer_sheet_to_index(wb, title, insert_at)
     return ws
+
+
+def _normalize_insert_index(wb: Any, index: int | None) -> int:
+    if index is None:
+        return len(wb._sheet_names)  # noqa: SLF001
+    if not isinstance(index, int):
+        raise TypeError("create_sheet index must be an int")
+    if index < 0:
+        return 0
+    return min(index, len(wb._sheet_names))  # noqa: SLF001
+
+
+def _move_new_writer_sheet_to_index(wb: Any, title: str, index: int) -> None:
+    current = len(wb._sheet_names) - 1  # noqa: SLF001
+    if index == current:
+        return
+    move = getattr(wb._rust_writer, "move_sheet", None)  # noqa: SLF001
+    if move is not None:
+        move(title, index - current)
 
 
 def copy_worksheet(

--- a/python/wolfxl/_workbook_sheets.py
+++ b/python/wolfxl/_workbook_sheets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from wolfxl._worksheet import Worksheet
@@ -33,22 +34,21 @@ def remove_sheet(wb: Any, worksheet: Worksheet) -> None:
         remove_fn(title)
 
 
-def create_sheet(wb: Any, title: str, index: int | None = None) -> Worksheet:
+def create_sheet(wb: Any, title: str | None, index: int | None = None) -> Worksheet:
     """Create and append a worksheet in write or modify mode.
 
     Args:
         wb: Workbook-like object carrying writer and sheet state.
-        title: Unique worksheet title.
+        title: Worksheet title. ``None``/``""`` and duplicate names are
+            resolved with openpyxl-style numeric suffixes.
 
     Returns:
         The newly created worksheet.
 
     Raises:
         RuntimeError: If ``wb`` is not in write mode.
-        ValueError: If ``title`` is already used.
     """
-    if title in wb._sheets or title in getattr(wb, "_chartsheets", {}):  # noqa: SLF001
-        raise ValueError(f"Sheet '{title}' already exists")
+    title = _unique_sheet_title(wb, title)
     insert_at = _normalize_insert_index(wb, index)
     if wb._rust_patcher is not None:  # noqa: SLF001
         wb._rust_patcher.queue_sheet_create(title, insert_at)  # noqa: SLF001
@@ -76,6 +76,22 @@ def create_sheet(wb: Any, title: str, index: int | None = None) -> Worksheet:
     wb._sheets[title] = ws  # noqa: SLF001
     _move_new_writer_sheet_to_index(wb, title, insert_at)
     return ws
+
+
+def _unique_sheet_title(wb: Any, title: str | None) -> str:
+    candidate = title or "Sheet"
+    names = [str(name) for name in wb._sheet_names]  # noqa: SLF001
+    if not any(name.lower() == candidate.lower() for name in names):
+        return candidate
+
+    joined_names = ",".join(names)
+    title_regex = re.compile(f"(?P<title>{re.escape(candidate)})(?P<count>\\d*),?", re.I)
+    counts = [
+        int(match.group("count"))
+        for match in title_regex.finditer(joined_names)
+        if match.group("count").isdigit()
+    ]
+    return f"{candidate}{max(counts) + 1 if counts else 1}"
 
 
 def _normalize_insert_index(wb: Any, index: int | None) -> int:

--- a/python/wolfxl/_workbook_sheets.py
+++ b/python/wolfxl/_workbook_sheets.py
@@ -46,7 +46,7 @@ def create_sheet(wb: Any, title: str) -> Worksheet:
     """
     if wb._rust_writer is None:  # noqa: SLF001
         raise RuntimeError("create_sheet requires write mode")
-    if title in wb._sheets:  # noqa: SLF001
+    if title in wb._sheets or title in getattr(wb, "_chartsheets", {}):  # noqa: SLF001
         raise ValueError(f"Sheet '{title}' already exists")
     # G20: streaming write-only mode dispatches to a different sheet
     # type — the eager Worksheet is materialisation-heavy, while

--- a/python/wolfxl/_workbook_sources.py
+++ b/python/wolfxl/_workbook_sources.py
@@ -19,6 +19,7 @@ def open_workbook_source(
     data: bytes | None,
     password: str | bytes | None,
     data_only: bool,
+    keep_links: bool,
     permissive: bool,
     modify: bool,
     read_only: bool,
@@ -47,6 +48,7 @@ def open_workbook_source(
                 data=data,
                 password=password,
                 data_only=data_only,
+                keep_links=keep_links,
                 permissive=permissive,
                 modify=modify,
                 read_only=read_only,
@@ -56,16 +58,24 @@ def open_workbook_source(
                 cls,
                 data,
                 data_only=data_only,
+                keep_links=keep_links,
                 permissive=permissive,
                 modify=modify,
                 read_only=read_only,
             )
         if modify:
-            return from_patcher(cls, path, data_only=data_only, permissive=permissive)
+            return from_patcher(
+                cls,
+                path,
+                data_only=data_only,
+                keep_links=keep_links,
+                permissive=permissive,
+            )
         return from_reader(
             cls,
             path,
             data_only=data_only,
+            keep_links=keep_links,
             permissive=permissive,
             read_only=read_only,
         )
@@ -96,6 +106,7 @@ def from_reader(
     path: str,
     *,
     data_only: bool = False,
+    keep_links: bool = True,
     permissive: bool = False,
     read_only: bool = False,
 ) -> Any:
@@ -115,6 +126,7 @@ def from_reader(
         data_only=data_only,
         read_only=read_only,
         source_path=path,
+        keep_links=keep_links,
     )
 
 
@@ -124,6 +136,7 @@ def _open_plain_xlsx_source(
     path: str | None,
     data: bytes | bytearray | memoryview | None,
     data_only: bool,
+    keep_links: bool,
     permissive: bool,
     modify: bool,
     read_only: bool,
@@ -131,11 +144,18 @@ def _open_plain_xlsx_source(
     """Open an unencrypted XLSX path or byte buffer with the requested mode."""
     if path is not None:
         if modify:
-            return from_patcher(cls, path, data_only=data_only, permissive=permissive)
+            return from_patcher(
+                cls,
+                path,
+                data_only=data_only,
+                keep_links=keep_links,
+                permissive=permissive,
+            )
         return from_reader(
             cls,
             path,
             data_only=data_only,
+            keep_links=keep_links,
             permissive=permissive,
             read_only=read_only,
         )
@@ -143,6 +163,7 @@ def _open_plain_xlsx_source(
         cls,
         bytes(data),  # type: ignore[arg-type]
         data_only=data_only,
+        keep_links=keep_links,
         permissive=permissive,
         modify=modify,
         read_only=read_only,
@@ -156,6 +177,7 @@ def from_encrypted(
     data: bytes | bytearray | memoryview | None = None,
     password: str | bytes,
     data_only: bool = False,
+    keep_links: bool = True,
     permissive: bool = False,
     modify: bool = False,
     read_only: bool = False,
@@ -176,6 +198,7 @@ def from_encrypted(
             path=path,
             data=data,
             data_only=data_only,
+            keep_links=keep_links,
             permissive=permissive,
             modify=modify,
             read_only=read_only,
@@ -210,6 +233,7 @@ def from_encrypted(
                 path=path,
                 data=data,
                 data_only=data_only,
+                keep_links=keep_links,
                 permissive=permissive,
                 modify=modify,
                 read_only=read_only,
@@ -235,6 +259,7 @@ def from_encrypted(
         cls,
         decrypted_bytes,
         data_only=data_only,
+        keep_links=keep_links,
         permissive=permissive,
         modify=modify,
         read_only=read_only,
@@ -246,6 +271,7 @@ def from_bytes(
     data: bytes | bytearray | memoryview,
     *,
     data_only: bool = False,
+    keep_links: bool = True,
     permissive: bool = False,
     modify: bool = False,
     read_only: bool = False,
@@ -274,13 +300,18 @@ def from_bytes(
 
         if modify:
             wb = from_patcher(
-                cls, tmp_path, data_only=data_only, permissive=permissive
+                cls,
+                tmp_path,
+                data_only=data_only,
+                keep_links=keep_links,
+                permissive=permissive,
             )
         else:
             wb = from_reader(
                 cls,
                 tmp_path,
                 data_only=data_only,
+                keep_links=keep_links,
                 permissive=permissive,
                 read_only=read_only,
             )
@@ -294,6 +325,8 @@ def from_bytes(
         data_only=data_only,
         read_only=read_only,
         source_path=None,
+        source_bytes=data_bytes,
+        keep_links=keep_links,
     )
 
 
@@ -302,6 +335,7 @@ def from_patcher(
     path: str,
     *,
     data_only: bool = False,
+    keep_links: bool = True,
     permissive: bool = False,
 ) -> Any:
     """Open an existing .xlsx file in modify mode."""
@@ -320,6 +354,7 @@ def from_patcher(
         data_only=data_only,
         read_only=False,
         source_path=path,
+        keep_links=keep_links,
     )
 
 

--- a/python/wolfxl/_workbook_state.py
+++ b/python/wolfxl/_workbook_state.py
@@ -134,11 +134,56 @@ def build_xlsb_xls_wb(
 
 def _initialize_sheet_proxies(wb: Any, rust_book: Any) -> None:
     """Attach worksheet proxies from a Rust reader's tab list."""
+    from wolfxl.chartsheet import Chartsheet
+
     names = [str(n) for n in rust_book.sheet_names()]
+    chartsheet_names = set(_read_chartsheet_names(rust_book))
     wb._sheet_names = names
-    wb._sheets = {name: Worksheet(wb, name) for name in names}
+    wb._sheets = {name: Worksheet(wb, name) for name in names if name not in chartsheet_names}
     wb._chartsheets = {}
+    for name in names:
+        if name in chartsheet_names:
+            cs = Chartsheet(wb, name)
+            cs._source_chartsheet = True
+            read_state = getattr(rust_book, "read_sheet_state", None)
+            if read_state is not None:
+                try:
+                    cs.sheet_state = read_state(name)
+                except Exception:
+                    pass
+            cs._charts = _read_chartsheet_charts(rust_book, name)
+            wb._chartsheets[name] = cs
     wb._chartsheets_dirty = False
+
+
+def _read_chartsheet_names(rust_book: Any) -> list[str]:
+    reader = getattr(rust_book, "chartsheet_names", None)
+    if reader is None:
+        return []
+    try:
+        return [str(n) for n in reader()]
+    except Exception:
+        return []
+
+
+def _read_chartsheet_charts(rust_book: Any, name: str) -> list[Any]:
+    reader = getattr(rust_book, "read_chartsheet_charts", None)
+    if reader is None:
+        return []
+    try:
+        payloads = reader(name)
+    except Exception:
+        return []
+
+    from wolfxl._worksheet_media import _chart_from_payload
+
+    charts = []
+    for payload in payloads:
+        if isinstance(payload, dict):
+            chart = _chart_from_payload(payload)
+            if chart is not None:
+                charts.append(chart)
+    return charts
 
 
 def initialize_pending_state(wb: Any) -> None:

--- a/python/wolfxl/_workbook_state.py
+++ b/python/wolfxl/_workbook_state.py
@@ -73,6 +73,8 @@ def build_xlsx_wb(
     data_only: bool,
     read_only: bool,
     source_path: str | None,
+    source_bytes: bytes | None = None,
+    keep_links: bool = True,
 ) -> Any:
     """Wire up read/modify-mode workbook fields shared by xlsx inputs.
 
@@ -99,6 +101,9 @@ def build_xlsx_wb(
     wb._evaluator = None
     wb._read_only = read_only
     wb._source_path = source_path
+    wb._source_bytes = source_bytes
+    wb._keep_links = keep_links
+    wb._strip_external_links_on_save = bool(rust_patcher is not None and not keep_links)
     wb._format = "xlsx"
     _initialize_sheet_proxies(wb, rust_reader)
     initialize_pending_state(wb)
@@ -209,6 +214,7 @@ def initialize_pending_state(wb: Any) -> None:
     wb._pending_range_moves = []
     wb._pending_sheet_copies = []
     wb._pending_chart_adds = {}
+    wb._pending_source_chart_ops = []
     wb._pending_pivot_caches = []
     wb._next_pivot_cache_id = 0
     wb._pending_slicer_caches = []

--- a/python/wolfxl/_workbook_state.py
+++ b/python/wolfxl/_workbook_state.py
@@ -137,10 +137,15 @@ def _initialize_sheet_proxies(wb: Any, rust_book: Any) -> None:
     names = [str(n) for n in rust_book.sheet_names()]
     wb._sheet_names = names
     wb._sheets = {name: Worksheet(wb, name) for name in names}
+    wb._chartsheets = {}
+    wb._chartsheets_dirty = False
 
 
 def initialize_pending_state(wb: Any) -> None:
     """Initialize workbook caches and pending mutation queues."""
+    if not hasattr(wb, "_chartsheets"):
+        wb._chartsheets = {}
+    wb._chartsheets_dirty = bool(getattr(wb, "_chartsheets_dirty", False))
     wb._properties_cache = None
     wb._custom_doc_props_cache = None
     wb._properties_dirty = False

--- a/python/wolfxl/_worksheet.py
+++ b/python/wolfxl/_worksheet.py
@@ -202,8 +202,12 @@ class Worksheet:
         old = self._title
         if old == value:
             return
-        if value in wb._sheets:  # noqa: SLF001
+        if value in wb._sheets or value in getattr(wb, "_chartsheets", {}):  # noqa: SLF001
             raise ValueError(f"Sheet '{value}' already exists")
+        if wb._rust_patcher is not None:  # noqa: SLF001
+            queue_rename = getattr(wb._rust_patcher, "queue_sheet_rename", None)  # noqa: SLF001
+            if queue_rename is not None:
+                queue_rename(old, value)
         # Update workbook bookkeeping.
         idx = wb._sheet_names.index(old)  # noqa: SLF001
         wb._sheet_names[idx] = value  # noqa: SLF001

--- a/python/wolfxl/_worksheet_media.py
+++ b/python/wolfxl/_worksheet_media.py
@@ -112,16 +112,21 @@ def validate_a1_anchor(anchor: str) -> None:
 
 
 def remove_chart(ws: Worksheet, chart: Any) -> None:
-    """Remove a not-yet-flushed chart from this worksheet."""
+    """Remove a chart from this worksheet."""
     try:
         ws._pending_charts.remove(chart)  # noqa: SLF001
+        return
     except ValueError:
+        pass
+    meta = getattr(chart, "_wolfxl_source_chart", None)
+    if meta is None:
         raise ValueError(
             "chart was not added to this worksheet via add_chart() "
-            "(or has already been removed). Removal of charts that "
-            "survive from the source workbook is a v1.8 follow-up; "
-            "see RFC-050 §6."
+            "(or has already been removed)."
         ) from None
+    if ws._charts_cache is not None and chart in ws._charts_cache:  # noqa: SLF001
+        ws._charts_cache.remove(chart)  # noqa: SLF001
+    _queue_source_chart_op(ws, {"op": "remove", "meta": meta})
 
 
 def replace_chart(ws: Worksheet, old: Any, new: Any) -> None:
@@ -136,7 +141,23 @@ def replace_chart(ws: Worksheet, old: Any, new: Any) -> None:
     try:
         index = ws._pending_charts.index(old)  # noqa: SLF001
     except ValueError:
-        raise ValueError("old chart was not added to this worksheet via add_chart()") from None
+        meta = getattr(old, "_wolfxl_source_chart", None)
+        if meta is None:
+            raise ValueError(
+                "old chart was not added to this worksheet via add_chart()"
+            ) from None
+        anchor = new._anchor if new._anchor is not None else old._anchor  # noqa: SLF001
+        if anchor is None:
+            anchor = "E15"
+        if isinstance(anchor, str):
+            validate_a1_anchor(anchor)
+        new._anchor = anchor  # noqa: SLF001
+        new._wolfxl_source_chart = meta  # noqa: SLF001
+        new._wolfxl_source_title = _title_signature(new)  # noqa: SLF001
+        if ws._charts_cache is not None and old in ws._charts_cache:  # noqa: SLF001
+            ws._charts_cache[ws._charts_cache.index(old)] = new  # noqa: SLF001
+        _queue_source_chart_op(ws, {"op": "replace", "meta": meta, "chart": new})
+        return
     anchor = new._anchor if new._anchor is not None else old._anchor  # noqa: SLF001
     if anchor is None:
         anchor = "E15"
@@ -155,14 +176,52 @@ def get_charts(ws: Worksheet) -> list[Any]:
 
     if ws._charts_cache is None:  # noqa: SLF001
         charts = []
-        for payload in reader.read_charts(ws._title):  # noqa: SLF001
+        source_refs = _source_chart_refs_for_ws(ws)
+        for idx, payload in enumerate(reader.read_charts(ws._title)):  # noqa: SLF001
             if isinstance(payload, dict):
                 chart = _chart_from_payload(payload)
                 if chart is not None:
+                    if idx < len(source_refs):
+                        chart._wolfxl_source_chart = source_refs[idx]  # noqa: SLF001
+                        chart._wolfxl_source_title = _title_signature(chart)  # noqa: SLF001
                     charts.append(chart)
         charts.extend(ws._pending_charts)  # noqa: SLF001
         ws._charts_cache = charts  # noqa: SLF001
     return ws._charts_cache  # noqa: SLF001
+
+
+def _source_chart_refs_for_ws(ws: Worksheet) -> list[dict[str, str]]:
+    workbook = ws._workbook  # noqa: SLF001
+    if getattr(workbook, "_rust_patcher", None) is None:
+        return []
+    from wolfxl import _source_charts
+
+    return _source_charts.source_chart_refs(
+        getattr(workbook, "_source_path", None), ws._title  # noqa: SLF001
+    )
+
+
+def _queue_source_chart_op(ws: Worksheet, op: dict[str, Any]) -> None:
+    workbook = ws._workbook  # noqa: SLF001
+    if getattr(workbook, "_rust_patcher", None) is None:
+        raise RuntimeError(
+            "source chart mutation requires modify mode — open the workbook "
+            "with load_workbook(..., modify=True)."
+        )
+    workbook._pending_source_chart_ops.append(op)  # noqa: SLF001
+
+
+def _title_signature(chart: Any) -> Any:
+    title = getattr(chart, "title", None)
+    if title is None:
+        return None
+    to_dict = getattr(title, "to_dict", None)
+    if to_dict is not None:
+        try:
+            return to_dict()
+        except Exception:
+            pass
+    return str(title)
 
 
 def _chart_from_payload(payload: dict[str, Any]) -> Any:

--- a/python/wolfxl/chartsheet/__init__.py
+++ b/python/wolfxl/chartsheet/__init__.py
@@ -1,0 +1,9 @@
+"""openpyxl-compatible chartsheet package."""
+
+from wolfxl.chartsheet.chartsheet import (
+    Chartsheet,
+    ChartsheetProperties,
+    ChartsheetProtection,
+)
+
+__all__ = ["Chartsheet", "ChartsheetProperties", "ChartsheetProtection"]

--- a/python/wolfxl/chartsheet/chartsheet.py
+++ b/python/wolfxl/chartsheet/chartsheet.py
@@ -32,6 +32,7 @@ class Chartsheet:
         self.sheet_properties = ChartsheetProperties()
         self.protection = ChartsheetProtection()
         self._charts: list[Any] = []
+        self._source_chartsheet = False
 
     def add_chart(self, chart: Any) -> None:
         """Attach ``chart`` to this chartsheet."""

--- a/python/wolfxl/chartsheet/chartsheet.py
+++ b/python/wolfxl/chartsheet/chartsheet.py
@@ -1,0 +1,47 @@
+"""Chartsheet containers compatible with ``openpyxl.chartsheet``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ChartsheetProperties:
+    """Small openpyxl-shaped chartsheet properties container."""
+
+    published: bool | None = None
+    codeName: str | None = None  # noqa: N815 - openpyxl camelCase
+
+
+@dataclass
+class ChartsheetProtection:
+    """Small openpyxl-shaped chartsheet protection container."""
+
+    content: bool | None = None
+    objects: bool | None = None
+
+
+class Chartsheet:
+    """A workbook tab that contains a single full-sheet chart."""
+
+    def __init__(self, parent: Any, title: str) -> None:
+        self._parent = parent
+        self.title = title
+        self.sheet_state = "visible"
+        self.sheet_properties = ChartsheetProperties()
+        self.protection = ChartsheetProtection()
+        self._charts: list[Any] = []
+
+    def add_chart(self, chart: Any) -> None:
+        """Attach ``chart`` to this chartsheet."""
+        if chart is None or not hasattr(chart, "to_rust_dict"):
+            raise TypeError(
+                f"Chartsheet.add_chart expects a wolfxl chart object, got {type(chart).__name__}"
+            )
+        self._charts[:] = [chart]
+
+    @property
+    def _drawing(self) -> Any | None:
+        """openpyxl-shaped private drawing placeholder."""
+        return self._charts[0] if self._charts else None

--- a/python/wolfxl/chartsheet/properties.py
+++ b/python/wolfxl/chartsheet/properties.py
@@ -1,0 +1,5 @@
+"""``openpyxl.chartsheet.properties`` compatibility."""
+
+from wolfxl.chartsheet.chartsheet import ChartsheetProperties
+
+__all__ = ["ChartsheetProperties"]

--- a/python/wolfxl/chartsheet/protection.py
+++ b/python/wolfxl/chartsheet/protection.py
@@ -1,0 +1,5 @@
+"""``openpyxl.chartsheet.protection`` compatibility."""
+
+from wolfxl.chartsheet.chartsheet import ChartsheetProtection
+
+__all__ = ["ChartsheetProtection"]

--- a/scripts/run_openpyxl_corpus.py
+++ b/scripts/run_openpyxl_corpus.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Run a cached openpyxl test corpus with ``openpyxl`` shimmed to ``wolfxl``.
+
+This is intentionally non-networked. Point it at a local openpyxl source
+checkout or a previously vendored test directory:
+
+    uv run --no-sync python scripts/run_openpyxl_corpus.py --corpus /tmp/openpyxl/tests
+
+The runner writes a machine-readable JSON summary and returns pytest's exit
+code when a corpus is present. With no corpus it exits 0 and reports
+``status=skipped`` unless ``--require-corpus`` is set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = ROOT / "tests" / "vendored_openpyxl"
+DEFAULT_ALLOWLIST = ROOT / "tests" / "vendored_openpyxl_allowlist.json"
+DEFAULT_REPORT = ROOT / "logs" / "openpyxl-corpus-summary.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--allowlist", type=Path, default=DEFAULT_ALLOWLIST)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--require-corpus", action="store_true")
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    corpus = args.corpus
+    report = args.report
+    report.parent.mkdir(parents=True, exist_ok=True)
+
+    if not corpus.exists():
+        payload = {
+            "status": "missing_corpus",
+            "corpus": str(corpus),
+            "allowlist": _load_allowlist(args.allowlist),
+            "message": "No cached openpyxl corpus found; pass --corpus or vendor tests first.",
+        }
+        report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        print(payload["message"])
+        return 2 if args.require_corpus else 0
+
+    with tempfile.TemporaryDirectory(prefix="wolfxl-openpyxl-corpus-") as tmp:
+        sitecustomize = Path(tmp) / "sitecustomize.py"
+        sitecustomize.write_text(
+            dedent(
+                """
+                import sys
+                import wolfxl
+
+                sys.modules.setdefault("openpyxl", wolfxl)
+                """
+            )
+        )
+        env = os.environ.copy()
+        env["PYTHONPATH"] = f"{tmp}{os.pathsep}{env.get('PYTHONPATH', '')}"
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(corpus),
+            "-q",
+            *args.pytest_args,
+        ]
+        proc = subprocess.run(cmd, cwd=ROOT, env=env, text=True, capture_output=True)
+
+    payload = {
+        "status": "passed" if proc.returncode == 0 else "failed",
+        "returncode": proc.returncode,
+        "corpus": str(corpus),
+        "allowlist": _load_allowlist(args.allowlist),
+        "stdout_tail": proc.stdout[-4000:],
+        "stderr_tail": proc.stderr[-4000:],
+    }
+    report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(proc.stdout, end="")
+    print(proc.stderr, end="", file=sys.stderr)
+    print(f"wrote {report}")
+    return proc.returncode
+
+
+def _load_allowlist(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {"entries": []}
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        return {"error": f"invalid allowlist JSON: {exc}"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/native_reader_backend.rs
+++ b/src/native_reader_backend.rs
@@ -56,6 +56,26 @@ impl NativeXlsxBook {
         self.sheet_names.clone()
     }
 
+    pub fn chartsheet_names(&self) -> Vec<String> {
+        self.book
+            .sheets()
+            .iter()
+            .filter(|sheet| sheet.path.contains("chartsheets/"))
+            .map(|sheet| sheet.name.clone())
+            .collect()
+    }
+
+    pub fn read_chartsheet_charts(&mut self, py: Python<'_>, sheet: &str) -> PyResult<PyObject> {
+        let charts = self.book.chartsheet_charts(sheet).map_err(|e| {
+            PyErr::new::<PyIOError, _>(format!("native chartsheet read failed: {e}"))
+        })?;
+        let result = pyo3::types::PyList::empty(py);
+        for chart in &charts {
+            result.append(crate::native_reader_drawings::chart_to_py(py, chart)?)?;
+        }
+        Ok(result.into())
+    }
+
     pub fn read_sheet_state(&self, sheet: &str) -> PyResult<&'static str> {
         crate::native_reader_workbook_basics::read_sheet_state_xlsx(self, sheet)
     }

--- a/src/native_writer_backend.rs
+++ b/src/native_writer_backend.rs
@@ -56,7 +56,7 @@ use crate::native_writer_sheet_state::{
 use crate::native_writer_streaming::{
     append_streaming_row, enable_streaming, finalize_all_streaming,
 };
-use crate::native_writer_workbook::{add_sheet_if_missing, move_sheet, rename_sheet, save_once};
+use crate::native_writer_workbook::{add_sheet_if_missing, move_sheet, rename_sheet};
 use crate::native_writer_workbook_metadata::{
     dict_to_defined_name, dict_to_doc_properties, dict_to_workbook_security,
 };
@@ -68,7 +68,6 @@ use crate::native_writer_workbook_metadata::{
 #[pyclass(unsendable)]
 pub struct NativeWorkbook {
     inner: Workbook,
-    saved: bool,
 }
 
 fn require_sheet<'wb>(wb: &'wb mut Workbook, name: &str) -> PyResult<&'wb mut Worksheet> {
@@ -86,7 +85,6 @@ impl NativeWorkbook {
     pub fn new() -> Self {
         Self {
             inner: Workbook::new(),
-            saved: false,
         }
     }
 
@@ -229,7 +227,7 @@ impl NativeWorkbook {
     }
 
     pub fn save(&mut self, path: &str) -> PyResult<()> {
-        save_once(&mut self.inner, &mut self.saved, path)
+        crate::native_writer_workbook::save(&mut self.inner, path)
     }
 
     // =========================================================================

--- a/src/native_writer_streaming.rs
+++ b/src/native_writer_streaming.rs
@@ -11,7 +11,7 @@
 //!    `wb._backend.append_streaming_row(name, row_idx, cells)` with a
 //!    Python list of cell payload dicts (or `None` to skip a column).
 //!    Index in the list is `column - 1` (1-based on Excel side).
-//! 3. `wb.save(path)` calls `save_once`, which now invokes
+//! 3. `wb.save(path)` calls the native workbook save helper, which invokes
 //!    `finalize_all_streaming` before `emit_xlsx` so each streaming
 //!    `BufWriter` is flushed to disk and the splice phase reads valid
 //!    bytes.

--- a/src/native_writer_workbook.rs
+++ b/src/native_writer_workbook.rs
@@ -24,15 +24,7 @@ pub(crate) fn move_sheet(wb: &mut Workbook, name: &str, offset: isize) -> PyResu
     wb.move_sheet(name, offset).map_err(PyValueError::new_err)
 }
 
-pub(crate) fn save_once(wb: &mut Workbook, saved: &mut bool, path: &str) -> PyResult<()> {
-    if *saved {
-        return Err(PyValueError::new_err(
-            "Workbook already saved (NativeWorkbook is consumed-on-save)",
-        ));
-    }
-    // Mark consumed before emit/write so a panic or failed write leaves the
-    // workbook un-retryable on potentially mutated state.
-    *saved = true;
+pub(crate) fn save(wb: &mut Workbook, path: &str) -> PyResult<()> {
     // G20: flush per-sheet streaming BufWriters so the splice phase
     // inside `emit_xlsx → sheet_xml::emit` reads consistent bytes.
     crate::native_writer_streaming::finalize_all_streaming(wb)?;

--- a/src/wolfxl/content_types.rs
+++ b/src/wolfxl/content_types.rs
@@ -56,6 +56,7 @@ const CT_NS: &str = "http://schemas.openxmlformats.org/package/2006/content-type
 #[allow(dead_code)] // No live caller in this slice; field reserved.
 pub enum ContentTypeOp {
     AddOverride(String, String),
+    RemoveOverride(String),
     EnsureDefault(String, String),
 }
 
@@ -174,6 +175,11 @@ impl ContentTypesGraph {
             .push((part.to_string(), content_type.to_string()));
     }
 
+    /// Remove an Override entry by part name. Idempotent.
+    pub fn remove_override(&mut self, part: &str) {
+        self.overrides.retain(|(p, _)| p != part);
+    }
+
     /// Append (or update in place) a Default entry. Same semantics as
     /// `add_override` keyed on `extension`.
     pub fn ensure_default(&mut self, extension: &str, content_type: &str) {
@@ -207,6 +213,7 @@ impl ContentTypesGraph {
     pub fn apply_op(&mut self, op: &ContentTypeOp) {
         match op {
             ContentTypeOp::AddOverride(part, ct) => self.add_override(part, ct),
+            ContentTypeOp::RemoveOverride(part) => self.remove_override(part),
             ContentTypeOp::EnsureDefault(ext, ct) => self.ensure_default(ext, ct),
         }
     }

--- a/src/wolfxl/mod.rs
+++ b/src/wolfxl/mod.rs
@@ -1235,8 +1235,6 @@ impl XlsxPatcher {
             )));
         };
         self.sheet_order.retain(|name| name != title);
-        self.deleted_sheet_paths.insert(title.to_string(), path);
-        self.queued_sheet_deletes.push(title.to_string());
         self.queued_dv_patches.remove(title);
         self.queued_cf_patches.remove(title);
         self.value_patches.retain(|(sheet, _), _| sheet != title);
@@ -1252,6 +1250,12 @@ impl XlsxPatcher {
         self.queued_autofilters.remove(title);
         self.queued_sheet_setup.remove(title);
         self.queued_page_breaks.remove(title);
+        if path.starts_with("__wolfxl_pending_sheet_create__/") {
+            self.queued_sheet_creates.retain(|op| op.title != title);
+            return Ok(());
+        }
+        self.deleted_sheet_paths.insert(title.to_string(), path);
+        self.queued_sheet_deletes.push(title.to_string());
         Ok(())
     }
 

--- a/src/wolfxl/mod.rs
+++ b/src/wolfxl/mod.rs
@@ -77,7 +77,9 @@ use zip::ZipArchive;
 use crate::ooxml_util;
 use conditional_formatting::{CfRulePatch, ConditionalFormattingPatch};
 use patcher_drawing::parse_queued_image_anchor;
-use patcher_models::{AxisShift, QueuedChartAdd, QueuedImageAdd, RangeMove, SheetCopyOp};
+use patcher_models::{
+    AxisShift, QueuedChartAdd, QueuedImageAdd, RangeMove, SheetCopyOp, SheetCreateOp,
+};
 use patcher_payload::{
     dict_to_border_spec, dict_to_format_spec, dict_to_threaded_entry, extract_bool,
     extract_cf_rule, extract_f64, extract_str, extract_u32, parse_workbook_security_payload,
@@ -268,6 +270,13 @@ pub struct XlsxPatcher {
     /// the cloned sheet is visible to downstream phases as if it
     /// had always been part of the source workbook.
     queued_sheet_copies: Vec<SheetCopyOp>,
+    /// Per-workbook blank sheet creation queue for modify mode.
+    queued_sheet_creates: Vec<SheetCreateOp>,
+    /// Per-workbook source sheet deletion queue for modify mode.
+    queued_sheet_deletes: Vec<String>,
+    /// Deleted sheet title -> original worksheet part path. Kept separate
+    /// because queue_sheet_delete removes the live sheet path eagerly.
+    deleted_sheet_paths: HashMap<String, String>,
     /// Sprint Θ Pod-A: pre-seeded `file_patches` entries produced by
     /// permissive-mode load-time normalization (e.g. rewriting an
     /// empty `<sheets/>` block in `xl/workbook.xml`). Empty in the
@@ -534,6 +543,9 @@ impl XlsxPatcher {
             queued_axis_shifts: Vec::new(),
             queued_range_moves: Vec::new(),
             queued_sheet_copies: Vec::new(),
+            queued_sheet_creates: Vec::new(),
+            queued_sheet_deletes: Vec::new(),
+            deleted_sheet_paths: HashMap::new(),
             permissive_seed_file_patches: file_patches,
             queued_images: HashMap::new(),
             queued_image_removes: HashMap::new(),
@@ -1183,6 +1195,63 @@ impl XlsxPatcher {
         rename_hash_key(&mut self.queued_page_breaks, old_name, new_name);
         self.queued_sheet_renames
             .push((old_name.to_string(), new_name.to_string()));
+        Ok(())
+    }
+
+    /// Queue creation of a blank worksheet in modify mode.
+    #[pyo3(signature = (title, index=None))]
+    fn queue_sheet_create(&mut self, title: &str, index: Option<usize>) -> PyResult<()> {
+        if title.is_empty() {
+            return Err(PyValueError::new_err(
+                "queue_sheet_create: sheet title must be non-empty",
+            ));
+        }
+        if self.sheet_paths.contains_key(title)
+            || self.queued_sheet_creates.iter().any(|op| op.title == title)
+        {
+            return Err(PyValueError::new_err(format!(
+                "queue_sheet_create: sheet '{title}' already exists"
+            )));
+        }
+        self.queued_sheet_creates.push(SheetCreateOp {
+            title: title.to_string(),
+        });
+        self.sheet_paths.insert(
+            title.to_string(),
+            format!("__wolfxl_pending_sheet_create__/{title}"),
+        );
+        let insert_at = index
+            .unwrap_or(self.sheet_order.len())
+            .min(self.sheet_order.len());
+        self.sheet_order.insert(insert_at, title.to_string());
+        Ok(())
+    }
+
+    /// Queue deletion of an existing worksheet in modify mode.
+    fn queue_sheet_delete(&mut self, title: &str) -> PyResult<()> {
+        let Some(path) = self.sheet_paths.remove(title) else {
+            return Err(PyValueError::new_err(format!(
+                "queue_sheet_delete: sheet '{title}' not found in workbook"
+            )));
+        };
+        self.sheet_order.retain(|name| name != title);
+        self.deleted_sheet_paths.insert(title.to_string(), path);
+        self.queued_sheet_deletes.push(title.to_string());
+        self.queued_dv_patches.remove(title);
+        self.queued_cf_patches.remove(title);
+        self.value_patches.retain(|(sheet, _), _| sheet != title);
+        self.format_patches.retain(|(sheet, _), _| sheet != title);
+        self.queued_hyperlinks.remove(title);
+        self.queued_tables.remove(title);
+        self.queued_comments.remove(title);
+        self.queued_threaded_comments.remove(title);
+        self.queued_images.remove(title);
+        self.queued_image_removes.remove(title);
+        self.queued_charts.remove(title);
+        self.queued_pivot_tables.remove(title);
+        self.queued_autofilters.remove(title);
+        self.queued_sheet_setup.remove(title);
+        self.queued_page_breaks.remove(title);
         Ok(())
     }
 
@@ -2032,6 +2101,22 @@ impl XlsxPatcher {
         // phase to write into it (workbook.xml + workbook.xml.rels).
         // Phase 3 mutates it further with per-sheet rewrites.
         patcher_workbook::drain_permissive_seed_file_patches_phase(self, &mut save.file_patches);
+
+        // --- Phase 2.6: Sheet deletes / creates ---
+        //
+        // Source sheet removal must run before blank-sheet creation so a user
+        // can remove a sheet and recreate the same title in one save session.
+        if !self.queued_sheet_deletes.is_empty() {
+            patcher_workbook::apply_sheet_deletes_phase(self, &mut save.file_patches, &mut zip)?;
+        }
+        if !self.queued_sheet_creates.is_empty() {
+            patcher_workbook::apply_sheet_creates_phase(
+                self,
+                &mut save.file_patches,
+                &mut zip,
+                &mut save.part_id_allocator,
+            )?;
+        }
 
         // --- Phase 2.7: Sheet copies (RFC-035) ---
         //

--- a/src/wolfxl/mod.rs
+++ b/src/wolfxl/mod.rs
@@ -244,6 +244,10 @@ pub struct XlsxPatcher {
     /// workbook.xml whose tab indices already reflect the move.
     /// Empty queue → no `xl/workbook.xml` touch.
     queued_sheet_moves: Vec<(String, i32)>,
+    /// Sheet-title rename operations pending flush. Queueing a rename also
+    /// updates `sheet_paths` and `sheet_order` immediately so subsequent
+    /// sheet-scoped mutations can use the new openpyxl-visible title.
+    queued_sheet_renames: Vec<(String, String)>,
     /// Per-workbook structural-shift queue (RFC-030 / RFC-031). Each
     /// entry is `(sheet, axis, idx, n)` where `axis` is "row" or "col"
     /// and `n` is signed (positive = insert, negative = delete).
@@ -352,6 +356,29 @@ pub struct XlsxPatcher {
     /// 2.5p (after Phase 2.5n sheet-setup, before Phase 2.5o
     /// autoFilter).
     queued_slicers: Vec<pivot_slicer::QueuedSlicer>,
+}
+
+fn rename_hash_key<T>(map: &mut HashMap<String, T>, old_name: &str, new_name: &str) {
+    if let Some(value) = map.remove(old_name) {
+        map.insert(new_name.to_string(), value);
+    }
+}
+
+fn rename_tuple_sheet_keys<T>(
+    map: &mut HashMap<(String, String), T>,
+    old_name: &str,
+    new_name: &str,
+) {
+    let keys: Vec<(String, String)> = map
+        .keys()
+        .filter(|(sheet, _)| sheet == old_name)
+        .cloned()
+        .collect();
+    for old_key in keys {
+        if let Some(value) = map.remove(&old_key) {
+            map.insert((new_name.to_string(), old_key.1), value);
+        }
+    }
 }
 
 #[pymethods]
@@ -503,6 +530,7 @@ impl XlsxPatcher {
             queued_threaded_comments: HashMap::new(),
             queued_persons: Vec::new(),
             queued_sheet_moves: Vec::new(),
+            queued_sheet_renames: Vec::new(),
             queued_axis_shifts: Vec::new(),
             queued_range_moves: Vec::new(),
             queued_sheet_copies: Vec::new(),
@@ -1099,6 +1127,62 @@ impl XlsxPatcher {
     /// the defined-names merger runs.
     fn queue_sheet_move(&mut self, sheet: &str, offset: i32) -> PyResult<()> {
         self.queued_sheet_moves.push((sheet.to_string(), offset));
+        Ok(())
+    }
+
+    /// Queue a sheet-title rename for modify mode.
+    ///
+    /// The in-memory maps are updated immediately so any later queued
+    /// sheet-scoped mutations can address the worksheet by its new title.
+    /// `xl/workbook.xml` is rewritten during the workbook XML phase.
+    fn queue_sheet_rename(&mut self, old_name: &str, new_name: &str) -> PyResult<()> {
+        if old_name == new_name {
+            return Ok(());
+        }
+        if new_name.is_empty() {
+            return Err(PyValueError::new_err(
+                "queue_sheet_rename: new sheet title must be non-empty",
+            ));
+        }
+        if self.sheet_paths.contains_key(new_name) {
+            return Err(PyValueError::new_err(format!(
+                "queue_sheet_rename: destination sheet '{new_name}' already exists"
+            )));
+        }
+        let Some(path) = self.sheet_paths.remove(old_name) else {
+            return Err(PyValueError::new_err(format!(
+                "queue_sheet_rename: source sheet '{old_name}' not found in workbook"
+            )));
+        };
+        self.sheet_paths.insert(new_name.to_string(), path);
+        for name in &mut self.sheet_order {
+            if name == old_name {
+                *name = new_name.to_string();
+            }
+        }
+        for (sheet, _) in &mut self.queued_sheet_moves {
+            if sheet == old_name {
+                *sheet = new_name.to_string();
+            }
+        }
+        rename_tuple_sheet_keys(&mut self.value_patches, old_name, new_name);
+        rename_tuple_sheet_keys(&mut self.format_patches, old_name, new_name);
+        rename_hash_key(&mut self.queued_dv_patches, old_name, new_name);
+        rename_hash_key(&mut self.queued_cf_patches, old_name, new_name);
+        rename_hash_key(&mut self.queued_content_type_ops, old_name, new_name);
+        rename_hash_key(&mut self.queued_hyperlinks, old_name, new_name);
+        rename_hash_key(&mut self.queued_tables, old_name, new_name);
+        rename_hash_key(&mut self.queued_comments, old_name, new_name);
+        rename_hash_key(&mut self.queued_threaded_comments, old_name, new_name);
+        rename_hash_key(&mut self.queued_images, old_name, new_name);
+        rename_hash_key(&mut self.queued_image_removes, old_name, new_name);
+        rename_hash_key(&mut self.queued_charts, old_name, new_name);
+        rename_hash_key(&mut self.queued_pivot_tables, old_name, new_name);
+        rename_hash_key(&mut self.queued_autofilters, old_name, new_name);
+        rename_hash_key(&mut self.queued_sheet_setup, old_name, new_name);
+        rename_hash_key(&mut self.queued_page_breaks, old_name, new_name);
+        self.queued_sheet_renames
+            .push((old_name.to_string(), new_name.to_string()));
         Ok(())
     }
 

--- a/src/wolfxl/patcher_drawing.rs
+++ b/src/wolfxl/patcher_drawing.rs
@@ -157,6 +157,138 @@ pub(crate) fn build_drawing_rels_xml(images: &[QueuedImageAdd], image_indices: &
     String::from_utf8(g.serialize()).expect("rels serialize is utf8")
 }
 
+/// Append one anchor per queued image to an existing drawing XML body.
+pub(crate) fn append_pic_anchors(
+    drawing_xml: &[u8],
+    queued: &[QueuedImageAdd],
+    image_rids: &[String],
+) -> Result<Vec<u8>, String> {
+    debug_assert_eq!(queued.len(), image_rids.len());
+    let body = std::str::from_utf8(drawing_xml).map_err(|e| e.to_string())?;
+    let use_xdr_prefix = body.contains("<xdr:wsDr") || body.contains("xmlns:xdr=");
+    let existing_count: u32 = (body.matches("<xdr:graphicFrame").count()
+        + body.matches("<graphicFrame").count()
+        + body.matches("<xdr:pic").count()
+        + body.matches("<pic").count()) as u32;
+    let mut new_anchors = String::with_capacity(queued.len() * 512);
+    for (i, (img, rid)) in queued.iter().zip(image_rids.iter()).enumerate() {
+        new_anchors.push_str(&render_pic_anchor_styled(
+            img,
+            rid,
+            existing_count + (i + 1) as u32,
+            use_xdr_prefix,
+        ));
+    }
+    let pos_opt = body.rfind("</xdr:wsDr>").or_else(|| body.rfind("</wsDr>"));
+    if let Some(pos) = pos_opt {
+        let mut out = String::with_capacity(body.len() + new_anchors.len());
+        out.push_str(&body[..pos]);
+        out.push_str(&new_anchors);
+        out.push_str(&body[pos..]);
+        Ok(out.into_bytes())
+    } else {
+        let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+        let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
+        let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        let mut out = String::with_capacity(new_anchors.len() + 256);
+        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n");
+        out.push_str(&format!(
+            "<xdr:wsDr xmlns:xdr=\"{xdr_ns}\" xmlns:a=\"{a_ns}\" xmlns:r=\"{r_ns}\">"
+        ));
+        out.push_str(&new_anchors);
+        out.push_str("</xdr:wsDr>");
+        Ok(out.into_bytes())
+    }
+}
+
+fn render_pic_anchor_styled(
+    img: &QueuedImageAdd,
+    image_rid: &str,
+    unique_id: u32,
+    use_xdr_prefix: bool,
+) -> String {
+    let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    let emu_per_px: i64 = 9525;
+    let p = if use_xdr_prefix { "xdr:" } else { "" };
+    let root_xmlns = if use_xdr_prefix {
+        String::new()
+    } else {
+        format!(" xmlns=\"{xdr_ns}\" xmlns:a=\"{a_ns}\" xmlns:r=\"{r_ns}\"")
+    };
+
+    let mut out = String::with_capacity(768);
+    match &img.anchor {
+        QueuedImageAnchor::OneCell {
+            from_col,
+            from_row,
+            from_col_off,
+            from_row_off,
+        } => {
+            out.push_str(&format!("<{p}oneCellAnchor{root_xmlns}>"));
+            out.push_str(&format!(
+                "<{p}from><{p}col>{from_col}</{p}col><{p}colOff>{from_col_off}</{p}colOff>\
+                 <{p}row>{from_row}</{p}row><{p}rowOff>{from_row_off}</{p}rowOff></{p}from>"
+            ));
+            let cx = img.width_px as i64 * emu_per_px;
+            let cy = img.height_px as i64 * emu_per_px;
+            out.push_str(&format!("<{p}ext cx=\"{cx}\" cy=\"{cy}\"/>"));
+        }
+        QueuedImageAnchor::TwoCell {
+            from_col,
+            from_row,
+            from_col_off,
+            from_row_off,
+            to_col,
+            to_row,
+            to_col_off,
+            to_row_off,
+            edit_as,
+        } => {
+            out.push_str(&format!(
+                "<{p}twoCellAnchor editAs=\"{edit_as}\"{root_xmlns}>"
+            ));
+            out.push_str(&format!(
+                "<{p}from><{p}col>{from_col}</{p}col><{p}colOff>{from_col_off}</{p}colOff>\
+                 <{p}row>{from_row}</{p}row><{p}rowOff>{from_row_off}</{p}rowOff></{p}from>"
+            ));
+            out.push_str(&format!(
+                "<{p}to><{p}col>{to_col}</{p}col><{p}colOff>{to_col_off}</{p}colOff>\
+                 <{p}row>{to_row}</{p}row><{p}rowOff>{to_row_off}</{p}rowOff></{p}to>"
+            ));
+        }
+        QueuedImageAnchor::Absolute {
+            x_emu,
+            y_emu,
+            cx_emu,
+            cy_emu,
+        } => {
+            out.push_str(&format!("<{p}absoluteAnchor{root_xmlns}>"));
+            out.push_str(&format!("<{p}pos x=\"{x_emu}\" y=\"{y_emu}\"/>"));
+            out.push_str(&format!("<{p}ext cx=\"{cx_emu}\" cy=\"{cy_emu}\"/>"));
+        }
+    }
+
+    let cx = img.width_px as i64 * emu_per_px;
+    let cy = img.height_px as i64 * emu_per_px;
+    out.push_str(&format!(
+        "<{p}pic xmlns:a=\"{a_ns}\" xmlns:r=\"{r_ns}\">\
+         <{p}nvPicPr><{p}cNvPr id=\"{unique_id}\" name=\"Picture {unique_id}\" descr=\"Picture {unique_id}\"/>\
+         <{p}cNvPicPr><a:picLocks noChangeAspect=\"1\"/></{p}cNvPicPr></{p}nvPicPr>\
+         <{p}blipFill><a:blip r:embed=\"{image_rid}\"/><a:stretch><a:fillRect/></a:stretch></{p}blipFill>\
+         <{p}spPr><a:xfrm><a:off x=\"0\" y=\"0\"/><a:ext cx=\"{cx}\" cy=\"{cy}\"/></a:xfrm>\
+         <a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom></{p}spPr></{p}pic>"
+    ));
+    out.push_str(&format!("<{p}clientData/>"));
+    match &img.anchor {
+        QueuedImageAnchor::OneCell { .. } => out.push_str(&format!("</{p}oneCellAnchor>")),
+        QueuedImageAnchor::TwoCell { .. } => out.push_str(&format!("</{p}twoCellAnchor>")),
+        QueuedImageAnchor::Absolute { .. } => out.push_str(&format!("</{p}absoluteAnchor>")),
+    }
+    out
+}
+
 /// Splice a `<drawing r:id="rIdN"/>` element into a sheet XML body.
 pub(crate) fn splice_drawing_ref(sheet_xml: &str, rid: &str) -> Result<String, &'static str> {
     if sheet_xml.contains("<drawing ") || sheet_xml.contains("<drawing/>") {
@@ -709,67 +841,27 @@ pub(super) fn apply_image_adds_phase(
                 }
             };
 
-        // 2. Reject if drawing rel already exists.
-        for r in rels_graph.iter() {
-            if r.rel_type == wolfxl_rels::rt::DRAWING {
-                return Err(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
-                    format!(
-                        "queue_image_add on sheet {sheet_name:?}: \
-                         sheet already has a drawing part — appending to an \
-                         existing drawing is a v1.5 follow-up. As a workaround, \
-                         remove the existing drawing first or open the file in \
-                         write mode."
-                    ),
-                ));
-            }
-        }
+        // 2. Probe for existing drawing rel + drawing path.
+        let existing_drawing_target = rels_graph
+            .iter()
+            .find(|r| r.rel_type == wolfxl_rels::rt::DRAWING)
+            .map(|r| r.target.clone());
 
-        // 3. Allocate part suffixes.
-        let drawing_n = part_id_allocator.alloc_drawing();
+        // 3. Allocate media part suffixes.
         let image_indices: Vec<u32> = queued
             .iter()
             .map(|_| part_id_allocator.alloc_image())
             .collect();
 
-        // 4. Synthesize drawing part XML + rels.
-        let drawing_xml = build_drawing_xml(&queued);
-        let drawing_rels_xml = build_drawing_rels_xml(&queued, &image_indices);
-        let drawing_path = format!("xl/drawings/drawing{drawing_n}.xml");
-        let drawing_rels_path = format!("xl/drawings/_rels/drawing{drawing_n}.xml.rels");
-        patcher
-            .file_adds
-            .insert(drawing_path.clone(), drawing_xml.into_bytes());
-        patcher
-            .file_adds
-            .insert(drawing_rels_path, drawing_rels_xml.into_bytes());
+        // 4. Add media parts.
         for (img, &n) in queued.iter().zip(image_indices.iter()) {
             let media_path = format!("xl/media/image{n}.{}", img.ext);
             patcher.file_adds.insert(media_path, img.data.clone());
         }
 
-        // 5. Add drawing rel to sheet rels graph.
-        let drawing_rid = rels_graph.add(
-            wolfxl_rels::rt::DRAWING,
-            &format!("../drawings/drawing{drawing_n}.xml"),
-            wolfxl_rels::TargetMode::Internal,
-        );
-        patcher.rels_patches.insert(sheet_rels_path, rels_graph);
-
-        // 6. Splice <drawing r:id> into sheet XML.
-        let sheet_xml = if let Some(b) = file_patches.get(&sheet_path) {
-            String::from_utf8_lossy(b).into_owned()
-        } else if let Some(b) = patcher.file_adds.get(&sheet_path) {
-            String::from_utf8_lossy(b).into_owned()
-        } else {
-            ooxml_util::zip_read_to_string(zip, &sheet_path)?
-        };
-        let after = splice_drawing_ref(&sheet_xml, &drawing_rid.0)
-            .map_err(|e| PyErr::new::<PyIOError, _>(format!("splice drawing: {e}")))?;
-        file_patches.insert(sheet_path, after.into_bytes());
-
-        // 7. Queue content-type ops.
+        // 5. Queue content-type ops.
         //    - one Default Extension per distinct extension
-        //    - one Override per drawing part
+        //    - one Override per drawing part only for fresh drawings
         let mut seen_exts: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut ops: Vec<content_types::ContentTypeOp> = Vec::new();
         for img in &queued {
@@ -787,13 +879,97 @@ pub(super) fn apply_image_adds_phase(
                 ));
             }
         }
-        ops.push(content_types::ContentTypeOp::AddOverride(
-            format!("/xl/drawings/drawing{drawing_n}.xml"),
-            "application/vnd.openxmlformats-officedocument.drawing+xml".to_string(),
-        ));
+
+        if let Some(target) = existing_drawing_target {
+            let sheet_dir = sheet_path
+                .rsplit_once('/')
+                .map(|(d, _)| d)
+                .unwrap_or("")
+                .to_string();
+            let drawing_path = resolve_relative_path(&sheet_dir, &target);
+            let drawing_rels_path = drawing_rels_path_for_part(&drawing_path)
+                .map_err(|e| PyErr::new::<PyIOError, _>(format!("drawing rels path: {e}")))?;
+            let mut drawing_rels: wolfxl_rels::RelsGraph = if let Some(g) =
+                patcher.rels_patches.get(&drawing_rels_path)
+            {
+                g.clone()
+            } else if let Some(bytes) = patcher.file_adds.get(&drawing_rels_path) {
+                wolfxl_rels::RelsGraph::parse(bytes)
+                    .map_err(|e| PyErr::new::<PyIOError, _>(format!("drawing rels parse: {e}")))?
+            } else {
+                match ooxml_util::zip_read_to_string_opt(zip, &drawing_rels_path)? {
+                    Some(s) => wolfxl_rels::RelsGraph::parse(s.as_bytes()).map_err(|e| {
+                        PyErr::new::<PyIOError, _>(format!("drawing rels parse: {e}"))
+                    })?,
+                    None => wolfxl_rels::RelsGraph::new(),
+                }
+            };
+            let mut image_rids: Vec<String> = Vec::with_capacity(queued.len());
+            for (img, &n) in queued.iter().zip(image_indices.iter()) {
+                let rid = drawing_rels.add(
+                    wolfxl_rels::rt::IMAGE,
+                    &format!("../media/image{n}.{}", img.ext),
+                    wolfxl_rels::TargetMode::Internal,
+                );
+                image_rids.push(rid.0);
+            }
+            let existing_drawing_xml: Vec<u8> = if let Some(bytes) = file_patches.get(&drawing_path)
+            {
+                bytes.clone()
+            } else if let Some(bytes) = patcher.file_adds.get(&drawing_path) {
+                bytes.clone()
+            } else {
+                ooxml_util::zip_read_to_string_opt(zip, &drawing_path)?
+                    .unwrap_or_default()
+                    .into_bytes()
+            };
+            let merged = append_pic_anchors(&existing_drawing_xml, &queued, &image_rids)
+                .map_err(|e| PyErr::new::<PyIOError, _>(format!("merge drawing: {e}")))?;
+            if zip.by_name(&drawing_path).is_ok() {
+                file_patches.insert(drawing_path.clone(), merged);
+            } else {
+                patcher.file_adds.insert(drawing_path.clone(), merged);
+            }
+            patcher.rels_patches.insert(drawing_rels_path, drawing_rels);
+        } else {
+            let drawing_n = part_id_allocator.alloc_drawing();
+            let drawing_xml = build_drawing_xml(&queued);
+            let drawing_rels_xml = build_drawing_rels_xml(&queued, &image_indices);
+            let drawing_path = format!("xl/drawings/drawing{drawing_n}.xml");
+            let drawing_rels_path = format!("xl/drawings/_rels/drawing{drawing_n}.xml.rels");
+            patcher
+                .file_adds
+                .insert(drawing_path.clone(), drawing_xml.into_bytes());
+            patcher
+                .file_adds
+                .insert(drawing_rels_path, drawing_rels_xml.into_bytes());
+
+            let drawing_rid = rels_graph.add(
+                wolfxl_rels::rt::DRAWING,
+                &format!("../drawings/drawing{drawing_n}.xml"),
+                wolfxl_rels::TargetMode::Internal,
+            );
+
+            let sheet_xml = if let Some(b) = file_patches.get(&sheet_path) {
+                String::from_utf8_lossy(b).into_owned()
+            } else if let Some(b) = patcher.file_adds.get(&sheet_path) {
+                String::from_utf8_lossy(b).into_owned()
+            } else {
+                ooxml_util::zip_read_to_string(zip, &sheet_path)?
+            };
+            let after = splice_drawing_ref(&sheet_xml, &drawing_rid.0)
+                .map_err(|e| PyErr::new::<PyIOError, _>(format!("splice drawing: {e}")))?;
+            file_patches.insert(sheet_path, after.into_bytes());
+
+            ops.push(content_types::ContentTypeOp::AddOverride(
+                format!("/xl/drawings/drawing{drawing_n}.xml"),
+                "application/vnd.openxmlformats-officedocument.drawing+xml".to_string(),
+            ));
+        }
+        patcher.rels_patches.insert(sheet_rels_path, rels_graph);
         patcher
             .queued_content_type_ops
-            .entry(format!("__rfc045_drawing_{drawing_n}__"))
+            .entry(format!("__rfc045_images_{sheet_name}__"))
             .or_default()
             .extend(ops);
     }
@@ -1118,6 +1294,31 @@ mod tests {
         assert!(s.contains("<xdr:oneCellAnchor/>"));
         assert!(s.contains("<xdr:graphicFrame"));
         assert!(s.contains("r:id=\"rId7\""));
+        assert!(s.ends_with("</xdr:wsDr>"));
+    }
+
+    #[test]
+    fn append_pic_anchor_inserts_before_close() {
+        let original = b"<?xml version=\"1.0\"?><xdr:wsDr xmlns:xdr=\"x\" xmlns:a=\"a\" xmlns:r=\"r\"><xdr:oneCellAnchor><xdr:pic><xdr:blipFill><a:blip r:embed=\"rId1\"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor></xdr:wsDr>";
+        let imgs = vec![QueuedImageAdd {
+            data: vec![],
+            ext: "png".into(),
+            width_px: 10,
+            height_px: 5,
+            anchor: QueuedImageAnchor::OneCell {
+                from_col: 3,
+                from_row: 4,
+                from_col_off: 0,
+                from_row_off: 0,
+            },
+        }];
+        let rids = vec!["rId2".to_string()];
+        let merged = append_pic_anchors(original, &imgs, &rids).unwrap();
+        let s = std::str::from_utf8(&merged).unwrap();
+        assert!(s.contains("r:embed=\"rId1\""));
+        assert!(s.contains("r:embed=\"rId2\""));
+        assert!(s.contains("<xdr:col>3</xdr:col>"));
+        assert_eq!(s.matches("<xdr:pic").count(), 2);
         assert!(s.ends_with("</xdr:wsDr>"));
     }
 

--- a/src/wolfxl/patcher_models.rs
+++ b/src/wolfxl/patcher_models.rs
@@ -67,6 +67,13 @@ pub struct SheetCopyOp {
     pub deep_copy_images: bool,
 }
 
+/// One queued blank worksheet creation in modify mode.
+#[derive(Debug, Clone)]
+pub struct SheetCreateOp {
+    /// Destination sheet title.
+    pub title: String,
+}
+
 /// One queued axis-shift op (RFC-030/031).
 #[derive(Debug, Clone)]
 pub struct AxisShift {

--- a/src/wolfxl/patcher_workbook.rs
+++ b/src/wolfxl/patcher_workbook.rs
@@ -10,11 +10,14 @@ use zip::write::SimpleFileOptions;
 use zip::{ZipArchive, ZipWriter};
 
 use crate::ooxml_util;
-use wolfxl_rels::RelsGraph;
+use wolfxl_rels::{RelId, RelsGraph};
 
 use super::{
     calcchain, content_types, defined_names, properties, security, sheet_order, XlsxPatcher,
 };
+
+const CT_WORKSHEET: &str =
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
 
 /// Maps a sheet XML path to its relationship sidecar path.
 pub(crate) fn sheet_rels_path_for(sheet_path: &str) -> String {
@@ -161,6 +164,230 @@ pub(crate) fn splice_into_sheets_block(
     Err(PyIOError::new_err(
         "Phase 2.7: workbook.xml has no <sheets> block",
     ))
+}
+
+pub(super) fn apply_sheet_deletes_phase(
+    patcher: &mut XlsxPatcher,
+    file_patches: &mut HashMap<String, Vec<u8>>,
+    zip: &mut ZipArchive<File>,
+) -> PyResult<()> {
+    if patcher.queued_sheet_deletes.is_empty() {
+        return Ok(());
+    }
+
+    let workbook_rels_path = "xl/_rels/workbook.xml.rels".to_string();
+    if !patcher.rels_patches.contains_key(&workbook_rels_path) {
+        let g = load_or_empty_rels(zip, &workbook_rels_path)?;
+        patcher.rels_patches.insert(workbook_rels_path.clone(), g);
+    }
+
+    let workbook_xml =
+        match current_part_bytes(file_patches, &patcher.file_adds, zip, "xl/workbook.xml") {
+            Some(b) => b,
+            None => {
+                return Err(PyIOError::new_err(
+                    "sheet-delete: xl/workbook.xml missing from source ZIP",
+                ));
+            }
+        };
+    let workbook_xml_text = std::str::from_utf8(&workbook_xml)
+        .map_err(|e| PyIOError::new_err(format!("sheet-delete workbook.xml utf8: {e}")))?;
+    let sheet_rids = ooxml_util::parse_workbook_sheet_rids(workbook_xml_text)
+        .map_err(|e| PyIOError::new_err(format!("sheet-delete workbook.xml parse: {e}")))?;
+
+    let deletes = patcher.queued_sheet_deletes.clone();
+    for title in &deletes {
+        if let Some((_, rid)) = sheet_rids.iter().find(|(name, _)| name == title) {
+            if let Some(graph) = patcher.rels_patches.get_mut(&workbook_rels_path) {
+                graph.remove(&RelId(rid.clone()));
+            }
+        }
+        let Some(sheet_path) = patcher.deleted_sheet_paths.get(title).cloned() else {
+            continue;
+        };
+        let sheet_rels_path = sheet_rels_path_for(&sheet_path);
+        let source_rels = if let Some(g) = patcher.rels_patches.get(&sheet_rels_path) {
+            g.clone()
+        } else {
+            load_or_empty_rels(zip, &sheet_rels_path)?
+        };
+        let subgraph = wolfxl_rels::walk_sheet_subgraph_with_nested(
+            &source_rels,
+            &sheet_path,
+            |part_path: &str| {
+                let rels_path = wolfxl_rels::rels_path_for(part_path)?;
+                let bytes = current_part_bytes(file_patches, &patcher.file_adds, zip, &rels_path)?;
+                RelsGraph::parse(&bytes).ok()
+            },
+        );
+        for part in subgraph.reachable_parts {
+            patcher.file_deletes.insert(part.clone());
+            if let Some(rels_path) = wolfxl_rels::rels_path_for(&part) {
+                patcher.file_deletes.insert(rels_path);
+            }
+            patcher
+                .queued_content_type_ops
+                .entry("__sheet_delete__".to_string())
+                .or_default()
+                .push(content_types::ContentTypeOp::RemoveOverride(format!(
+                    "/{part}"
+                )));
+        }
+        patcher.file_deletes.insert(sheet_rels_path);
+    }
+
+    let result = sheet_order::merge_sheet_deletes(&workbook_xml, &deletes)
+        .map_err(|e| PyIOError::new_err(format!("sheet-delete merge: {e}")))?;
+    file_patches.insert("xl/workbook.xml".to_string(), result.workbook_xml);
+    patcher.sheet_order = result.new_order;
+    patcher.queued_sheet_deletes.clear();
+    patcher.deleted_sheet_paths.clear();
+    Ok(())
+}
+
+pub(super) fn apply_sheet_creates_phase(
+    patcher: &mut XlsxPatcher,
+    file_patches: &mut HashMap<String, Vec<u8>>,
+    zip: &mut ZipArchive<File>,
+    part_id_allocator: &mut wolfxl_rels::PartIdAllocator,
+) -> PyResult<()> {
+    if patcher.queued_sheet_creates.is_empty() {
+        return Ok(());
+    }
+
+    let workbook_rels_path = "xl/_rels/workbook.xml.rels".to_string();
+    if !patcher.rels_patches.contains_key(&workbook_rels_path) {
+        let g = load_or_empty_rels(zip, &workbook_rels_path)?;
+        patcher.rels_patches.insert(workbook_rels_path.clone(), g);
+    }
+
+    let desired_order = patcher.sheet_order.clone();
+    let queued_titles: HashSet<String> = patcher
+        .queued_sheet_creates
+        .iter()
+        .map(|op| op.title.clone())
+        .collect();
+    let mut created_titles: HashSet<String> = HashSet::new();
+    let ops = patcher.queued_sheet_creates.clone();
+    for op in ops {
+        let sheet_n = part_id_allocator.alloc_sheet();
+        let sheet_path = format!("xl/worksheets/sheet{sheet_n}.xml");
+        let target = format!("worksheets/sheet{sheet_n}.xml");
+        let rid = {
+            let graph = patcher
+                .rels_patches
+                .get_mut(&workbook_rels_path)
+                .expect("workbook rels graph loaded above");
+            graph.add(
+                wolfxl_rels::rt::WORKSHEET,
+                &target,
+                wolfxl_rels::TargetMode::Internal,
+            )
+        };
+
+        let workbook_xml =
+            match current_part_bytes(file_patches, &patcher.file_adds, zip, "xl/workbook.xml") {
+                Some(b) => b,
+                None => {
+                    return Err(PyIOError::new_err(
+                        "sheet-create: xl/workbook.xml missing from source ZIP",
+                    ));
+                }
+            };
+        let sheet_id = next_sheet_id(&workbook_xml);
+        let sheet_element = format!(
+            "<sheet name=\"{}\" sheetId=\"{}\" r:id=\"{}\"/>",
+            xml_escape_attr(&op.title),
+            sheet_id,
+            xml_escape_attr(&rid.0)
+        )
+        .into_bytes();
+        let mut workbook_xml = splice_into_sheets_block(&workbook_xml, &sheet_element)?;
+
+        let desired_idx = desired_order
+            .iter()
+            .take_while(|name| *name != &op.title)
+            .filter(|name| !queued_titles.contains(*name) || created_titles.contains(*name))
+            .count();
+        let last_idx = next_sheet_count(&workbook_xml).saturating_sub(1);
+        if desired_idx != last_idx {
+            let offset = desired_idx as i32 - last_idx as i32;
+            let result =
+                sheet_order::merge_sheet_moves(&workbook_xml, &[(op.title.clone(), offset)])
+                    .map_err(|e| PyIOError::new_err(format!("sheet-create order: {e}")))?;
+            workbook_xml = result.workbook_xml;
+        }
+        file_patches.insert("xl/workbook.xml".to_string(), workbook_xml);
+        patcher
+            .file_adds
+            .insert(sheet_path.clone(), minimal_worksheet_xml());
+        patcher
+            .sheet_paths
+            .insert(op.title.clone(), sheet_path.clone());
+        patcher
+            .queued_content_type_ops
+            .entry("__sheet_create__".to_string())
+            .or_default()
+            .push(content_types::ContentTypeOp::AddOverride(
+                format!("/{sheet_path}"),
+                CT_WORKSHEET.to_string(),
+            ));
+        created_titles.insert(op.title.clone());
+    }
+
+    patcher.sheet_order = desired_order;
+    patcher.queued_sheet_creates.clear();
+    Ok(())
+}
+
+fn minimal_worksheet_xml() -> Vec<u8> {
+    br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheetData/></worksheet>"#.to_vec()
+}
+
+fn next_sheet_id(workbook_xml: &[u8]) -> u32 {
+    max_sheet_id_and_count(workbook_xml)
+        .0
+        .saturating_add(1)
+        .max(1)
+}
+
+fn next_sheet_count(workbook_xml: &[u8]) -> usize {
+    max_sheet_id_and_count(workbook_xml).1
+}
+
+fn max_sheet_id_and_count(workbook_xml: &[u8]) -> (u32, usize) {
+    let mut reader = quick_xml::Reader::from_reader(workbook_xml);
+    reader.config_mut().trim_text(false);
+    let mut buf = Vec::new();
+    let mut max_id = 0_u32;
+    let mut count = 0_usize;
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(quick_xml::events::Event::Start(e)) | Ok(quick_xml::events::Event::Empty(e))
+                if e.local_name().as_ref() == b"sheet" =>
+            {
+                count += 1;
+                for attr in e.attributes().with_checks(false).flatten() {
+                    if attr.key.as_ref() == b"sheetId" {
+                        let value = attr
+                            .unescape_value()
+                            .map(|v| v.into_owned())
+                            .unwrap_or_else(|_| {
+                                String::from_utf8_lossy(attr.value.as_ref()).into_owned()
+                            });
+                        if let Ok(parsed) = value.parse::<u32>() {
+                            max_id = max_id.max(parsed);
+                        }
+                    }
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    (max_id, count)
 }
 
 fn workbook_root_has_relationship_namespace(s: &str) -> PyResult<bool> {
@@ -439,6 +666,8 @@ pub(super) fn has_pending_save_work(patcher: &XlsxPatcher) -> bool {
         || !patcher.queued_axis_shifts.is_empty()
         || !patcher.queued_range_moves.is_empty()
         || !patcher.queued_sheet_copies.is_empty()
+        || !patcher.queued_sheet_creates.is_empty()
+        || !patcher.queued_sheet_deletes.is_empty()
         || !patcher.queued_images.is_empty()
         || !patcher.queued_charts.is_empty()
         || !patcher.queued_pivot_caches.is_empty()

--- a/src/wolfxl/patcher_workbook.rs
+++ b/src/wolfxl/patcher_workbook.rs
@@ -352,7 +352,8 @@ pub(super) fn apply_document_properties_phase(
 }
 
 // These phases all mutate xl/workbook.xml, so keep the in-progress bytes flowing
-// security -> sheet order -> defined names before publishing the final patch.
+// security -> sheet renames -> sheet order -> defined names before publishing
+// the final patch.
 pub(super) fn apply_workbook_xml_phases(
     patcher: &mut XlsxPatcher,
     file_patches: &mut HashMap<String, Vec<u8>>,
@@ -370,6 +371,19 @@ pub(super) fn apply_workbook_xml_phases(
                 .map_err(|e| PyIOError::new_err(format!("workbook-security merge: {e}")))?;
             workbook_xml_in_progress = Some(updated);
         }
+    }
+
+    if !patcher.queued_sheet_renames.is_empty() {
+        let wb_bytes: Vec<u8> = match workbook_xml_in_progress.take() {
+            Some(b) => b,
+            None => match file_patches.get("xl/workbook.xml") {
+                Some(b) => b.clone(),
+                None => ooxml_util::zip_read_to_string(zip, "xl/workbook.xml")?.into_bytes(),
+            },
+        };
+        let updated = sheet_order::merge_sheet_renames(&wb_bytes, &patcher.queued_sheet_renames)
+            .map_err(|e| PyIOError::new_err(format!("sheet-rename merge: {e}")))?;
+        workbook_xml_in_progress = Some(updated);
     }
 
     if !patcher.queued_sheet_moves.is_empty() {
@@ -420,6 +434,7 @@ pub(super) fn has_pending_save_work(patcher: &XlsxPatcher) -> bool {
         || !patcher.queued_defined_names.is_empty()
         || !patcher.queued_tables.is_empty()
         || !patcher.queued_comments.is_empty()
+        || !patcher.queued_sheet_renames.is_empty()
         || !patcher.queued_sheet_moves.is_empty()
         || !patcher.queued_axis_shifts.is_empty()
         || !patcher.queued_range_moves.is_empty()

--- a/src/wolfxl/patcher_workbook.rs
+++ b/src/wolfxl/patcher_workbook.rs
@@ -270,6 +270,9 @@ pub(super) fn apply_sheet_creates_phase(
     let mut created_titles: HashSet<String> = HashSet::new();
     let ops = patcher.queued_sheet_creates.clone();
     for op in ops {
+        if !desired_order.contains(&op.title) {
+            continue;
+        }
         let sheet_n = part_id_allocator.alloc_sheet();
         let sheet_path = format!("xl/worksheets/sheet{sheet_n}.xml");
         let target = format!("worksheets/sheet{sheet_n}.xml");

--- a/src/wolfxl/sheet_order.rs
+++ b/src/wolfxl/sheet_order.rs
@@ -218,6 +218,67 @@ fn rename_sheet_event(
     Ok(out)
 }
 
+/// Remove `<sheet>` entries from `xl/workbook.xml` and keep sheet-scoped
+/// defined names aligned with the surviving tab indexes.
+pub fn merge_sheet_deletes(
+    workbook_xml: &[u8],
+    deletes: &[String],
+) -> Result<SheetOrderResult, String> {
+    let layout = scan_workbook_layout(workbook_xml)?;
+    if deletes.is_empty() {
+        return Ok(SheetOrderResult {
+            workbook_xml: workbook_xml.to_vec(),
+            new_order: layout
+                .sheet_entries
+                .iter()
+                .map(|e| e.name.clone())
+                .collect(),
+        });
+    }
+
+    let delete_set: std::collections::BTreeSet<&str> = deletes.iter().map(|s| s.as_str()).collect();
+    let mut deleted_positions: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+    let mut entries: Vec<SheetEntry> = Vec::new();
+    for entry in &layout.sheet_entries {
+        if delete_set.contains(entry.name.as_str()) {
+            deleted_positions.insert(entry.original_pos);
+        } else {
+            entries.push(entry.clone());
+        }
+    }
+
+    let mut remap: BTreeMap<u32, u32> = BTreeMap::new();
+    for (new_pos, entry) in entries.iter().enumerate() {
+        if entry.original_pos as usize != new_pos {
+            remap.insert(entry.original_pos, new_pos as u32);
+        }
+    }
+
+    let mut rewritten_sheets: Vec<u8> = Vec::with_capacity(layout.sheets_inner_len());
+    for entry in &entries {
+        rewritten_sheets.extend_from_slice(&entry.raw);
+    }
+    let with_sheets_rewritten = splice_sheets_inner(
+        workbook_xml,
+        layout.sheets_inner_start,
+        layout.sheets_inner_end,
+        &rewritten_sheets,
+    );
+
+    let without_deleted_defined_names =
+        remove_defined_names_for_deleted_sheets(&with_sheets_rewritten, &deleted_positions)?;
+    let final_bytes = if remap.is_empty() {
+        without_deleted_defined_names
+    } else {
+        rewrite_local_sheet_ids(&without_deleted_defined_names, &remap)?
+    };
+
+    Ok(SheetOrderResult {
+        workbook_xml: final_bytes,
+        new_order: entries.iter().map(|e| e.name.clone()).collect(),
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Internal: layout scan
 // ---------------------------------------------------------------------------
@@ -414,6 +475,71 @@ fn rewrite_local_sheet_ids(src: &[u8], remap: &BTreeMap<u32, u32>) -> Result<Vec
         out.extend_from_slice(&src[cursor..*val_start]);
         out.extend_from_slice(new_val.as_bytes());
         cursor = *val_end;
+    }
+    out.extend_from_slice(&src[cursor..]);
+    Ok(out)
+}
+
+fn remove_defined_names_for_deleted_sheets(
+    src: &[u8],
+    deleted_positions: &std::collections::BTreeSet<u32>,
+) -> Result<Vec<u8>, String> {
+    if deleted_positions.is_empty() {
+        return Ok(src.to_vec());
+    }
+    let s = std::str::from_utf8(src)
+        .map_err(|e| format!("workbook.xml is not valid UTF-8 after sheet delete: {e}"))?;
+    let mut reader = XmlReader::from_str(s);
+    reader.config_mut().trim_text(false);
+    let mut buf: Vec<u8> = Vec::new();
+    let mut removals: Vec<(usize, usize)> = Vec::new();
+    let mut active_defined_name: Option<(usize, u32)> = None;
+
+    loop {
+        let pre = reader.buffer_position() as usize;
+        let evt = reader.read_event_into(&mut buf);
+        let post = reader.buffer_position() as usize;
+        match evt {
+            Ok(Event::Empty(ref e)) if e.local_name().as_ref() == b"definedName" => {
+                if let Some((_, _, old)) = find_local_sheet_id_value(s.as_bytes(), pre) {
+                    if let Ok(parsed) = old.parse::<u32>() {
+                        if deleted_positions.contains(&parsed) {
+                            removals.push((pre, post));
+                        }
+                    }
+                }
+            }
+            Ok(Event::Start(ref e)) if e.local_name().as_ref() == b"definedName" => {
+                if let Some((_, _, old)) = find_local_sheet_id_value(s.as_bytes(), pre) {
+                    if let Ok(parsed) = old.parse::<u32>() {
+                        if deleted_positions.contains(&parsed) {
+                            active_defined_name = Some((pre, parsed));
+                        }
+                    }
+                }
+            }
+            Ok(Event::End(ref e)) if e.local_name().as_ref() == b"definedName" => {
+                if let Some((start, _)) = active_defined_name.take() {
+                    removals.push((start, post));
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(format!("definedName delete scan error: {e}")),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    if removals.is_empty() {
+        return Ok(src.to_vec());
+    }
+
+    removals.sort_by_key(|(start, _)| *start);
+    let mut out = Vec::with_capacity(src.len());
+    let mut cursor = 0;
+    for (start, end) in removals {
+        out.extend_from_slice(&src[cursor..start]);
+        cursor = end;
     }
     out.extend_from_slice(&src[cursor..]);
     Ok(out)

--- a/src/wolfxl/sheet_order.rs
+++ b/src/wolfxl/sheet_order.rs
@@ -30,8 +30,9 @@
 
 use std::collections::BTreeMap;
 
-use quick_xml::events::Event;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader as XmlReader;
+use quick_xml::Writer as XmlWriter;
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -144,6 +145,77 @@ pub fn merge_sheet_moves(
         workbook_xml: final_bytes,
         new_order,
     })
+}
+
+/// Rename `<sheet name="...">` attributes in `xl/workbook.xml`.
+///
+/// Used by modify mode when a loaded worksheet's `.title` is changed. The
+/// patcher updates its in-memory sheet maps eagerly, while this function makes
+/// the workbook tab name mutation durable in the saved OOXML.
+pub fn merge_sheet_renames(
+    workbook_xml: &[u8],
+    renames: &[(String, String)],
+) -> Result<Vec<u8>, String> {
+    if renames.is_empty() {
+        return Ok(workbook_xml.to_vec());
+    }
+    let rename_map: BTreeMap<&str, &str> = renames
+        .iter()
+        .map(|(old, new)| (old.as_str(), new.as_str()))
+        .collect();
+
+    let mut reader = XmlReader::from_reader(workbook_xml);
+    reader.config_mut().trim_text(false);
+    let mut writer = XmlWriter::new(Vec::with_capacity(workbook_xml.len()));
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == b"sheet" => {
+                let renamed = rename_sheet_event(&e, &rename_map)?;
+                writer
+                    .write_event(Event::Start(renamed))
+                    .map_err(|e| format!("workbook.xml write error: {e}"))?;
+            }
+            Ok(Event::Empty(e)) if e.local_name().as_ref() == b"sheet" => {
+                let renamed = rename_sheet_event(&e, &rename_map)?;
+                writer
+                    .write_event(Event::Empty(renamed))
+                    .map_err(|e| format!("workbook.xml write error: {e}"))?;
+            }
+            Ok(Event::Eof) => break,
+            Ok(event) => writer
+                .write_event(event)
+                .map_err(|e| format!("workbook.xml write error: {e}"))?,
+            Err(e) => return Err(format!("workbook.xml parse error: {e}")),
+        }
+        buf.clear();
+    }
+
+    Ok(writer.into_inner())
+}
+
+fn rename_sheet_event(
+    event: &BytesStart<'_>,
+    rename_map: &BTreeMap<&str, &str>,
+) -> Result<BytesStart<'static>, String> {
+    let mut out = BytesStart::new(String::from_utf8_lossy(event.name().as_ref()).into_owned());
+    for attr in event.attributes().with_checks(false) {
+        let attr = attr.map_err(|e| format!("workbook.xml sheet attr error: {e}"))?;
+        if attr.key.as_ref() == b"name" {
+            let value = attr
+                .unescape_value()
+                .map_err(|e| format!("workbook.xml sheet name decode error: {e}"))?;
+            if let Some(new_name) = rename_map.get(value.as_ref()) {
+                out.push_attribute(("name", *new_name));
+            } else {
+                out.push_attribute(("name", value.as_ref()));
+            }
+        } else {
+            out.push_attribute(attr);
+        }
+    }
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/parity/openpyxl_surface.py
+++ b/tests/parity/openpyxl_surface.py
@@ -765,9 +765,8 @@ _GAP_ENTRIES: tuple[SurfaceEntry, ...] = (
             "bytes (no Pillow dependency), exposes ``.format``, "
             "``.width``, ``.height``, ``.anchor``. Pairs with "
             "``Worksheet.add_image`` for both write- and modify-mode "
-            "image insertion. Modify-mode appending to a sheet that "
-            "already has a drawing part raises NotImplementedError "
-            "(v1.5 limit; tracked as RFC-045 follow-up)."
+            "image insertion, including appending into sheets that "
+            "already have drawing parts."
         ),
         wolfxl_supported=True,
         write_api=True,

--- a/tests/parity/test_copy_worksheet_parity.py
+++ b/tests/parity/test_copy_worksheet_parity.py
@@ -395,7 +395,8 @@ def test_parity_image_aliasing_wolf_aliases_op_deep_copies(tmp_path: Path) -> No
     except (ImportError, Exception) as exc:  # pragma: no cover
         pytest.skip(f"image fixture build failed (likely missing pillow): {exc}")
 
-    # wolfxl path — may not yet support image-bearing copy fully.
+    # wolfxl path — image-bearing copy is supported; this guard turns any
+    # regression into a clear historical-ledger pointer.
     wb_w = load_workbook(src, modify=True)
     try:
         wb_w.copy_worksheet(wb_w.active)
@@ -403,8 +404,8 @@ def test_parity_image_aliasing_wolf_aliases_op_deep_copies(tmp_path: Path) -> No
     except Exception as exc:  # pragma: no cover
         pytest.xfail(
             f"wolfxl image-bearing copy_worksheet failed: "
-            f"{type(exc).__name__}: {exc}. Documented as a "
-            "follow-up at KNOWN_GAPS.md."
+            f"{type(exc).__name__}: {exc}. See the historical copy_worksheet "
+            "notes in KNOWN_GAPS.md."
         )
 
     # openpyxl path
@@ -424,7 +425,7 @@ def test_parity_image_aliasing_wolf_aliases_op_deep_copies(tmp_path: Path) -> No
         pytest.xfail(
             f"wolfxl emitted {len(wolf_media)} media entries — "
             "RFC-035 §5.3 aliasing contract expects 1. "
-            "Tracked at KNOWN_GAPS.md as a future follow-up."
+            "See the historical copy_worksheet notes in KNOWN_GAPS.md."
         )
     assert len(wolf_media) == 1, (
         f"wolfxl should alias image media (one entry expected); "

--- a/tests/parity/test_openpyxl_path_compat.py
+++ b/tests/parity/test_openpyxl_path_compat.py
@@ -233,6 +233,14 @@ PATHS: list[tuple[str, str]] = [
     ("openpyxl.chart.data_source", "AxDataSource"),
     ("openpyxl.chart.data_source", "StrRef"),
 
+    # ---- chartsheet ------------------------------------------------------
+    ("openpyxl.chartsheet", "Chartsheet"),
+    ("openpyxl.chartsheet.chartsheet", "Chartsheet"),
+    ("openpyxl.chartsheet.chartsheet", "ChartsheetProperties"),
+    ("openpyxl.chartsheet.chartsheet", "ChartsheetProtection"),
+    ("openpyxl.chartsheet.properties", "ChartsheetProperties"),
+    ("openpyxl.chartsheet.protection", "ChartsheetProtection"),
+
     # ---- pivot -----------------------------------------------------------
     ("openpyxl.pivot.table", "PivotTable"),
     ("openpyxl.pivot.table", "TableDefinition"),

--- a/tests/parity/test_read_parity.py
+++ b/tests/parity/test_read_parity.py
@@ -103,8 +103,8 @@ def _diff_sheet(
     op_max_row = op_ws.max_row
     op_max_col = op_ws.max_column
 
-    # wolfxl 0.3.2 exposes these via private methods; fall back gracefully so
-    # this test still runs on a pre-fix build.
+    # Older wolfxl wheels exposed these via private methods; keep the fallback
+    # so this parity harness can still compare archived baseline wheels.
     wx_max_row = getattr(wx_ws, "max_row", None)
     if wx_max_row is None and hasattr(wx_ws, "_max_row"):
         wx_max_row = wx_ws._max_row()  # noqa: SLF001
@@ -169,14 +169,10 @@ def _normalize_value(v: Any) -> Any:
 
 
 def _normalize_number_format(v: Any) -> Any:
-    """openpyxl returns ``'General'`` for unformatted cells; wolfxl 0.3.2
-    returns ``None``. Both mean "no explicit format" — coerce to ``'General'``.
+    """Normalize archived pre-fix ``None`` values to openpyxl's ``'General'``.
 
-    Tracked as a Phase 0 cleanup item in ``KNOWN_GAPS.md``: wolfxl's
-    ``Cell.number_format`` should match openpyxl's contract and return
-    ``'General'`` for unformatted cells. Until that lands, this normalization
-    keeps the harness green without hiding real number-format mismatches
-    (anything other than the None-vs-General case still surfaces).
+    Current wolfxl matches openpyxl here; the coercion keeps the harness useful
+    for old baseline wheels without hiding other number-format mismatches.
     """
     if v is None:
         return "General"

--- a/tests/test_charts_remove.py
+++ b/tests/test_charts_remove.py
@@ -20,6 +20,7 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+import openpyxl
 import pytest
 
 
@@ -47,6 +48,26 @@ def _build_workbook_with_pending_chart() -> tuple[Any, Any, Any]:
     ws.add_chart(bar, "E2")
 
     return wb, ws, bar
+
+
+def _build_openpyxl_chart_fixture(path: Path) -> None:
+    from openpyxl.chart import BarChart, Reference
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Data"
+    rows = [
+        ["Region", "Q1", "Q2"],
+        ["NA", 100, 110],
+        ["EU", 80, 95],
+    ]
+    for row in rows:
+        ws.append(row)
+    chart = BarChart()
+    chart.title = "Original"
+    chart.add_data(Reference(ws, min_col=2, min_row=1, max_col=3, max_row=3), titles_from_data=True)
+    ws.add_chart(chart, "E2")
+    wb.save(path)
 
 
 def test_remove_chart_drops_pending(tmp_path: Path) -> None:
@@ -77,6 +98,65 @@ def test_remove_chart_unknown_raises() -> None:
     ghost = BarChart()
     with pytest.raises(ValueError, match="not added"):
         ws.remove_chart(ghost)
+
+
+def test_remove_loaded_source_chart_persists(tmp_path: Path) -> None:
+    import wolfxl
+
+    src = tmp_path / "source_chart.xlsx"
+    _build_openpyxl_chart_fixture(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    ws = wb["Data"]
+    chart = ws._charts[0]
+    ws.remove_chart(chart)
+    out = tmp_path / "removed_source_chart.xlsx"
+    wb.save(out)
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded["Data"]._charts == []
+    with zipfile.ZipFile(out) as zf:
+        assert not any(name.startswith("xl/charts/chart") for name in zf.namelist())
+
+
+def test_replace_loaded_source_chart_persists(tmp_path: Path) -> None:
+    import wolfxl
+    from wolfxl.chart import LineChart, Reference
+
+    src = tmp_path / "source_chart_replace.xlsx"
+    _build_openpyxl_chart_fixture(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    ws = wb["Data"]
+    old = ws._charts[0]
+    line = LineChart()
+    line.title = "Replacement"
+    line.add_data(Reference(ws, min_col=2, min_row=1, max_col=3, max_row=3), titles_from_data=True)
+    ws.replace_chart(old, line)
+    out = tmp_path / "replaced_source_chart.xlsx"
+    wb.save(out)
+
+    with zipfile.ZipFile(out) as zf:
+        chart_xml = zf.read("xl/charts/chart1.xml").decode("utf-8")
+    assert "<c:lineChart>" in chart_xml
+    assert "<c:barChart>" not in chart_xml
+
+
+def test_loaded_source_chart_title_edit_persists(tmp_path: Path) -> None:
+    import wolfxl
+
+    src = tmp_path / "source_chart_title.xlsx"
+    _build_openpyxl_chart_fixture(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    wb["Data"]._charts[0].title = "Changed"
+    out = tmp_path / "title_changed.xlsx"
+    wb.save(out)
+
+    with zipfile.ZipFile(out) as zf:
+        chart_xml = zf.read("xl/charts/chart1.xml").decode("utf-8")
+    assert "Changed" in chart_xml
+    assert "Original" not in chart_xml
 
 
 def test_replace_chart_swaps_in_place(tmp_path: Path) -> None:

--- a/tests/test_chartsheets.py
+++ b/tests/test_chartsheets.py
@@ -114,6 +114,33 @@ def test_chartsheet_can_be_inserted_between_worksheets(tmp_path: Path) -> None:
     assert [cs.title for cs in op.chartsheets] == ["Middle"]
 
 
+def test_chartsheet_insert_remaps_sheet_local_defined_names(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+    from openpyxl.workbook.defined_name import DefinedName
+
+    src = tmp_path / "defined_name_source.xlsx"
+    op = openpyxl.Workbook()
+    op.active.title = "First"
+    op.create_sheet("Second")
+    op.defined_names["SecondLocal"] = DefinedName(
+        "SecondLocal",
+        attr_text="Second!$A$1",
+        localSheetId=1,
+    )
+    op.save(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    wb.create_chartsheet("Chart", index=1)
+    out = tmp_path / "defined_name_with_chartsheet.xlsx"
+    wb.save(out)
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded.sheetnames == ["First", "Chart", "Second"]
+    with zipfile.ZipFile(out) as z:
+        workbook_xml = z.read("xl/workbook.xml").decode()
+    assert 'name="SecondLocal" localSheetId="2"' in workbook_xml
+
+
 def test_empty_chartsheet_saves_like_openpyxl(tmp_path: Path) -> None:
     openpyxl = pytest.importorskip("openpyxl")
 

--- a/tests/test_chartsheets.py
+++ b/tests/test_chartsheets.py
@@ -52,6 +52,24 @@ def test_create_chartsheet_with_chart_round_trips_through_openpyxl(tmp_path: Pat
         assert "/xl/chartsheets/sheet1.xml" in content_types
 
 
+def test_eager_chartsheet_survives_second_save(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    wb, chart = _workbook_with_chart()
+    cs = wb.create_chartsheet("Sales Chart")
+    cs.add_chart(chart)
+    first = tmp_path / "first.xlsx"
+    second = tmp_path / "second.xlsx"
+    wb.save(first)
+    wb.active["C1"] = "resaved"
+    wb.save(second)
+
+    op = openpyxl.load_workbook(second)
+    assert op.sheetnames == ["Sheet", "Sales Chart"]
+    assert [cs.title for cs in op.chartsheets] == ["Sales Chart"]
+    assert len(op.chartsheets[0]._charts) == 1  # noqa: SLF001
+
+
 def test_create_chartsheet_in_modify_mode_round_trips(tmp_path: Path) -> None:
     openpyxl = pytest.importorskip("openpyxl")
 
@@ -114,3 +132,52 @@ def test_empty_chartsheet_saves_like_openpyxl(tmp_path: Path) -> None:
         assert "xl/chartsheets/_rels/sheet1.xml.rels" in names
         rels = z.read("xl/chartsheets/_rels/sheet1.xml.rels").decode()
         assert "<Relationship " not in rels
+
+
+def test_openpyxl_authored_chartsheet_loads_as_chartsheet(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    src = tmp_path / "openpyxl_chartsheet.xlsx"
+    op = openpyxl.Workbook()
+    ws = op.active
+    ws.append(["month", "sales"])
+    ws.append(["Jan", 10])
+    ws.append(["Feb", 20])
+    chart = openpyxl.chart.BarChart()
+    chart.add_data(openpyxl.chart.Reference(ws, min_col=2, min_row=1, max_row=3))
+    cs = op.create_chartsheet("ChartOnly")
+    cs.add_chart(chart)
+    op.save(src)
+
+    wb = wolfxl.load_workbook(src)
+    assert wb.sheetnames == ["Sheet", "ChartOnly"]
+    assert [ws.title for ws in wb.worksheets] == ["Sheet"]
+    assert [cs.title for cs in wb.chartsheets] == ["ChartOnly"]
+    assert wb["ChartOnly"] is wb.chartsheets[0]
+    assert len(wb.chartsheets[0]._charts) == 1  # noqa: SLF001
+
+
+def test_openpyxl_authored_chartsheet_is_preserved_on_modify_save(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    src = tmp_path / "source.xlsx"
+    op = openpyxl.Workbook()
+    ws = op.active
+    ws.append(["month", "sales"])
+    ws.append(["Jan", 10])
+    ws.append(["Feb", 20])
+    chart = openpyxl.chart.BarChart()
+    chart.add_data(openpyxl.chart.Reference(ws, min_col=2, min_row=1, max_row=3))
+    cs = op.create_chartsheet("ChartOnly")
+    cs.add_chart(chart)
+    op.save(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    wb["Sheet"]["C1"] = "edited"
+    out = tmp_path / "modified.xlsx"
+    wb.save(out)
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded["Sheet"]["C1"].value == "edited"
+    assert [cs.title for cs in reloaded.chartsheets] == ["ChartOnly"]
+    assert len(reloaded.chartsheets[0]._charts) == 1  # noqa: SLF001

--- a/tests/test_chartsheets.py
+++ b/tests/test_chartsheets.py
@@ -1,0 +1,116 @@
+"""Chartsheet authoring parity smoke tests."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import wolfxl
+from wolfxl.chart import BarChart, Reference
+
+
+def _workbook_with_chart() -> tuple[wolfxl.Workbook, BarChart]:
+    wb = wolfxl.Workbook()
+    ws = wb.active
+    assert ws is not None
+    ws.append(["month", "sales"])
+    ws.append(["Jan", 10])
+    ws.append(["Feb", 20])
+    chart = BarChart()
+    chart.add_data(Reference(ws, min_col=2, min_row=1, max_row=3), titles_from_data=True)
+    chart.set_categories(Reference(ws, min_col=1, min_row=2, max_row=3))
+    return wb, chart
+
+
+def test_create_chartsheet_with_chart_round_trips_through_openpyxl(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    wb, chart = _workbook_with_chart()
+    cs = wb.create_chartsheet("Sales Chart")
+    cs.add_chart(chart)
+    out = tmp_path / "chartsheet.xlsx"
+    wb.save(out)
+
+    op = openpyxl.load_workbook(out)
+    assert op.sheetnames == ["Sheet", "Sales Chart"]
+    assert len(op.chartsheets) == 1
+    assert op.chartsheets[0].title == "Sales Chart"
+    assert len(op.chartsheets[0]._charts) == 1  # noqa: SLF001
+
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+        assert "xl/chartsheets/sheet1.xml" in names
+        assert "xl/chartsheets/_rels/sheet1.xml.rels" in names
+        assert "xl/drawings/drawing1.xml" in names
+        assert "xl/drawings/_rels/drawing1.xml.rels" in names
+        assert "xl/charts/chart1.xml" in names
+        workbook_rels = z.read("xl/_rels/workbook.xml.rels").decode()
+        assert "/relationships/chartsheet" in workbook_rels
+        content_types = z.read("[Content_Types].xml").decode()
+        assert "/xl/chartsheets/sheet1.xml" in content_types
+
+
+def test_create_chartsheet_in_modify_mode_round_trips(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    src = tmp_path / "source.xlsx"
+    op = openpyxl.Workbook()
+    ws = op.active
+    ws.title = "Data"
+    ws.append(["month", "sales"])
+    ws.append(["Jan", 10])
+    ws.append(["Feb", 20])
+    op.save(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    data = wb["Data"]
+    chart = BarChart()
+    chart.add_data(Reference(data, min_col=2, min_row=1, max_row=3), titles_from_data=True)
+    chart.set_categories(Reference(data, min_col=1, min_row=2, max_row=3))
+    cs = wb.create_chartsheet("Sales Chart")
+    cs.add_chart(chart)
+    out = tmp_path / "modify_chartsheet.xlsx"
+    wb.save(out)
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded.sheetnames == ["Data", "Sales Chart"]
+    assert [cs.title for cs in reloaded.chartsheets] == ["Sales Chart"]
+    assert len(reloaded.chartsheets[0]._charts) == 1  # noqa: SLF001
+
+
+def test_chartsheet_can_be_inserted_between_worksheets(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    wb, chart = _workbook_with_chart()
+    wb.create_sheet("After")
+    cs = wb.create_chartsheet("Middle", index=1)
+    cs.add_chart(chart)
+    out = tmp_path / "chartsheet_middle.xlsx"
+    wb.save(out)
+
+    op = openpyxl.load_workbook(out)
+    assert op.sheetnames == ["Sheet", "Middle", "After"]
+    assert [ws.title for ws in op.worksheets] == ["Sheet", "After"]
+    assert [cs.title for cs in op.chartsheets] == ["Middle"]
+
+
+def test_empty_chartsheet_saves_like_openpyxl(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    wb = wolfxl.Workbook()
+    wb.create_chartsheet("Empty Chart")
+    out = tmp_path / "empty_chartsheet.xlsx"
+    wb.save(out)
+
+    op = openpyxl.load_workbook(out)
+    assert op.sheetnames == ["Sheet", "Empty Chart"]
+    assert [cs.title for cs in op.chartsheets] == ["Empty Chart"]
+
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+        assert "xl/chartsheets/sheet1.xml" in names
+        assert "xl/chartsheets/_rels/sheet1.xml.rels" in names
+        rels = z.read("xl/chartsheets/_rels/sheet1.xml.rels").decode()
+        assert "<Relationship " not in rels

--- a/tests/test_external_links.py
+++ b/tests/test_external_links.py
@@ -201,6 +201,19 @@ def test_real_fixture_exposes_link(fixture_path: Path) -> None:
     assert link.rid == "rId2"  # the externalLink rel id in the workbook rels
 
 
+def test_keep_links_false_hides_external_links(fixture_path: Path) -> None:
+    wb = wolfxl.load_workbook(fixture_path, keep_links=False)
+    assert wb._external_links == []
+
+
+def test_bytes_backed_external_links_are_loaded(fixture_path: Path) -> None:
+    data = fixture_path.read_bytes()
+    for source in (data, io.BytesIO(data)):
+        wb = wolfxl.load_workbook(source)
+        assert len(wb._external_links) == 1
+        assert wb._external_links[0].target == "ext.xlsx"
+
+
 def test_modify_mode_preserves_external_link_bytes(
     fixture_path: Path, tmp_path: Path
 ) -> None:
@@ -294,6 +307,25 @@ def test_remove_external_link_prunes_parts_and_workbook_wiring(
     wb = wolfxl.load_workbook(fixture_path, modify=True)
     wb._external_links.clear()
     out = tmp_path / "removed.xlsx"
+    wb.save(out)
+
+    with zipfile.ZipFile(out, "r") as zf:
+        names = set(zf.namelist())
+        wb_xml = zf.read("xl/workbook.xml").decode("utf-8")
+        wb_rels = zf.read("xl/_rels/workbook.xml.rels").decode("utf-8")
+        ct_xml = zf.read("[Content_Types].xml").decode("utf-8")
+
+    assert not any(name.startswith("xl/externalLinks/") for name in names)
+    assert "<externalReferences>" not in wb_xml
+    assert "relationships/externalLink" not in wb_rels
+    assert "/xl/externalLinks/" not in ct_xml
+
+
+def test_keep_links_false_modify_save_strips_external_links(
+    fixture_path: Path, tmp_path: Path
+) -> None:
+    wb = wolfxl.load_workbook(fixture_path, modify=True, keep_links=False)
+    out = tmp_path / "keep_links_false.xlsx"
     wb.save(out)
 
     with zipfile.ZipFile(out, "r") as zf:

--- a/tests/test_images_modify.py
+++ b/tests/test_images_modify.py
@@ -4,7 +4,7 @@ Counterpart to ``test_images_write.py``. Verifies that
 ``ws.add_image(Image(...))`` works in modify mode (load → mutate →
 save) and produces a valid xlsx with all the same parts. Also
 exercises the v1.5 limit: appending to a sheet that already has a
-drawing part raises ``NotImplementedError``.
+drawing part now merges into the existing drawing part.
 """
 
 from __future__ import annotations
@@ -95,20 +95,36 @@ def test_modify_multiple_images(tmp_path: Path) -> None:
         assert d_rels.count("/relationships/image") == 2
 
 
-def test_modify_append_to_existing_drawing_raises(tmp_path: Path) -> None:
-    """v1.5 limit — appending to a sheet that already has a drawing part."""
+def test_modify_append_to_existing_drawing_round_trip(tmp_path: Path) -> None:
+    """Appending to a sheet that already has a drawing part preserves both images."""
+    openpyxl = pytest.importorskip("openpyxl")
+
     # Stage 1: create a workbook WITH an image (so it has a drawing rel).
     wb = wolfxl.Workbook()
     wb.active.add_image(Image(PNG_PATH), "B5")
     base = tmp_path / "with_drawing.xlsx"
     wb.save(base)
 
-    # Stage 2: open in modify mode, try to add another image — should
-    # raise NotImplementedError.
+    # Stage 2: open in modify mode, add another image into the existing drawing.
     wb2 = load_workbook(base, modify=True)
     wb2.active.add_image(Image(JPG_PATH), "D4")
-    with pytest.raises(NotImplementedError, match="(?i)drawing"):
-        wb2.save(tmp_path / "boom.xlsx")
+    out = tmp_path / "merged_drawing.xlsx"
+    wb2.save(out)
+
+    wb3 = openpyxl.load_workbook(out)
+    images = wb3.active._images
+    assert len(images) == 2
+    assert _image_anchor_col_row(images[0]) == (1, 4)  # B5
+    assert _image_anchor_col_row(images[1]) == (3, 3)  # D4
+
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+        drawing_files = sorted(n for n in names if n.startswith("xl/drawings/drawing"))
+        assert drawing_files == ["xl/drawings/drawing1.xml"]
+        drawing = z.read("xl/drawings/drawing1.xml").decode()
+        assert drawing.count("<xdr:pic") == 2
+        rels = z.read("xl/drawings/_rels/drawing1.xml.rels").decode()
+        assert rels.count("/relationships/image") == 2
 
 
 def test_modify_remove_image_by_index_round_trip(tmp_path: Path) -> None:

--- a/tests/test_move_sheet_modify.py
+++ b/tests/test_move_sheet_modify.py
@@ -129,6 +129,41 @@ def test_rfc036_write_mode_move_sheet_persists_on_save(tmp_path: Path) -> None:
     assert rt["C"]["A1"].value == "charlie"
 
 
+def test_modify_mode_worksheet_rename_persists_on_save(tmp_path: Path) -> None:
+    """Renaming a loaded worksheet must update workbook.xml like openpyxl."""
+    src = tmp_path / "rename_src.xlsx"
+    _make_two_sheet_fixture(src)
+
+    wb = load_workbook(src, modify=True)
+    wb["First"].title = "Renamed"
+    out = tmp_path / "renamed.xlsx"
+    wb.save(out)
+    wb.close()
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded.sheetnames == ["Renamed", "Second"]
+    assert reloaded["Renamed"]["A1"].value == "first"
+
+
+def test_modify_mode_rename_then_edit_uses_new_title(tmp_path: Path) -> None:
+    """Queued mutations after rename should target the renamed worksheet."""
+    src = tmp_path / "rename_edit_src.xlsx"
+    _make_two_sheet_fixture(src)
+
+    wb = load_workbook(src, modify=True)
+    ws = wb["First"]
+    ws.title = "Renamed"
+    ws["B1"] = "after"
+    out = tmp_path / "renamed_edited.xlsx"
+    wb.save(out)
+    wb.close()
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded.sheetnames == ["Renamed", "Second"]
+    assert reloaded["Renamed"]["A1"].value == "first"
+    assert reloaded["Renamed"]["B1"].value == "after"
+
+
 def test_rfc036_move_sheet_accepts_worksheet_instance() -> None:
     wb = Workbook()
     wb.create_sheet("Second")

--- a/tests/test_move_sheet_modify.py
+++ b/tests/test_move_sheet_modify.py
@@ -145,6 +145,38 @@ def test_modify_mode_worksheet_rename_persists_on_save(tmp_path: Path) -> None:
     assert reloaded["Renamed"]["A1"].value == "first"
 
 
+def test_modify_mode_create_sheet_persists_with_cells_and_order(tmp_path: Path) -> None:
+    src = tmp_path / "create_src.xlsx"
+    _make_two_sheet_fixture(src)
+
+    wb = load_workbook(src, modify=True)
+    ws = wb.create_sheet("Inserted", index=1)
+    ws["A1"] = "created"
+    out = tmp_path / "created.xlsx"
+    wb.save(out)
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded.sheetnames == ["First", "Inserted", "Second"]
+    assert reloaded["Inserted"]["A1"].value == "created"
+    with zipfile.ZipFile(out, "r") as zf:
+        names = set(zf.namelist())
+    assert any(name.startswith("xl/worksheets/sheet") for name in names)
+
+
+def test_modify_mode_remove_sheet_prunes_tab_and_part(tmp_path: Path) -> None:
+    src = tmp_path / "remove_src.xlsx"
+    _make_two_sheet_fixture(src)
+
+    wb = load_workbook(src, modify=True)
+    wb.remove(wb["Second"])
+    out = tmp_path / "removed.xlsx"
+    wb.save(out)
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded.sheetnames == ["First"]
+    assert "Second" not in reloaded.sheetnames
+
+
 def test_modify_mode_rename_then_edit_uses_new_title(tmp_path: Path) -> None:
     """Queued mutations after rename should target the renamed worksheet."""
     src = tmp_path / "rename_edit_src.xlsx"

--- a/tests/test_move_sheet_modify.py
+++ b/tests/test_move_sheet_modify.py
@@ -163,6 +163,23 @@ def test_modify_mode_create_sheet_persists_with_cells_and_order(tmp_path: Path) 
     assert any(name.startswith("xl/worksheets/sheet") for name in names)
 
 
+def test_modify_mode_create_sheet_auto_names_and_create_remove_noops(tmp_path: Path) -> None:
+    src = tmp_path / "create_autoname_src.xlsx"
+    _make_two_sheet_fixture(src)
+
+    wb = load_workbook(src, modify=True)
+    assert wb.create_sheet().title == "Sheet"
+    assert wb.create_sheet("First").title == "First1"
+    transient = wb.create_sheet("Transient")
+    wb.remove(transient)
+    out = tmp_path / "create_autoname.xlsx"
+    wb.save(out)
+
+    reloaded = openpyxl.load_workbook(out)
+    assert reloaded.sheetnames == ["First", "Second", "Sheet", "First1"]
+    assert "Transient" not in reloaded.sheetnames
+
+
 def test_modify_mode_remove_sheet_prunes_tab_and_part(tmp_path: Path) -> None:
     src = tmp_path / "remove_src.xlsx"
     _make_two_sheet_fixture(src)

--- a/tests/test_native_save_lifecycle.py
+++ b/tests/test_native_save_lifecycle.py
@@ -1,23 +1,18 @@
-"""W4E.P1 regression: NativeWorkbook is consumed-on-save.
+"""Native write-mode save lifecycle parity.
 
-The fix: ``self.saved = true`` is set *before* the emit/write so a
-panic in ``emit_xlsx`` or ``fs::write`` cannot leave the workbook in
-a state where a retry would re-emit on partially-mutated data.
-
-These tests assert the consumed-on-save contract holds for the native
-pyclass — the sole write-mode backend as of W5.
+Openpyxl eager workbooks can be edited and saved repeatedly. WolfXL's native
+writer must match that behavior; only ``Workbook(write_only=True)`` is
+consumed-on-save.
 """
 from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
-
-def test_second_save_raises_already_saved_native(tmp_path: Path) -> None:
-    """A successful save() consumes the workbook; a second save() must
-    raise (no silent overwrite, no retry path)."""
+def test_eager_workbook_can_save_again_after_more_edits(tmp_path: Path) -> None:
+    """A successful eager save does not consume the workbook."""
     import wolfxl
+    from openpyxl import load_workbook
 
     wb = wolfxl.Workbook()
     ws = wb.active
@@ -27,22 +22,19 @@ def test_second_save_raises_already_saved_native(tmp_path: Path) -> None:
     wb.save(str(out1))
     assert out1.exists() and out1.stat().st_size > 0
 
+    ws.cell(row=1, column=2, value="again")
     out2 = tmp_path / "second.xlsx"
-    with pytest.raises(Exception) as exc_info:
-        wb.save(str(out2))
-    assert "already saved" in str(exc_info.value).lower(), (
-        f"expected 'already saved' in error, got: {exc_info.value!r}"
-    )
-    assert not out2.exists(), "second save() must not write any output"
+    wb.save(str(out2))
+
+    reloaded = load_workbook(out2)
+    assert reloaded.active["A1"].value == "hello"
+    assert reloaded.active["B1"].value == "again"
 
 
-def test_failed_save_still_consumes_workbook_native(tmp_path: Path) -> None:
-    """W4E.P1 invariant: even if the first save() fails (e.g. unwritable
-    path), the workbook is still marked saved. Retrying after a partial
-    failure could re-emit on partially-mutated state — the lifecycle is
-    designed to fail loudly instead.
-    """
+def test_eager_workbook_can_retry_after_failed_save(tmp_path: Path) -> None:
+    """A failed eager save should not make openpyxl-style retry impossible."""
     import wolfxl
+    from openpyxl import load_workbook
 
     wb = wolfxl.Workbook()
     ws = wb.active
@@ -52,16 +44,13 @@ def test_failed_save_still_consumes_workbook_native(tmp_path: Path) -> None:
     # /dev/full on Linux always-fails-write; on macOS we use a directory
     # path that doesn't exist. Either yields a write error from fs::write.
     bad_path = str(tmp_path / "no_such_dir" / "bad.xlsx")
-    with pytest.raises(Exception):
+    try:
         wb.save(bad_path)
+    except Exception:
+        pass
+    else:  # pragma: no cover - defensive; the path should fail on all platforms
+        raise AssertionError("expected save to nonexistent directory to fail")
 
-    # Second save() — even to a valid path — must still raise
-    # 'already saved'. Crucial: retry-on-failure is forbidden.
     good_path = tmp_path / "good.xlsx"
-    with pytest.raises(Exception) as exc_info:
-        wb.save(str(good_path))
-    assert "already saved" in str(exc_info.value).lower(), (
-        f"after failed first save, second save did not raise "
-        f"'already saved': got {exc_info.value!r}"
-    )
-    assert not good_path.exists(), "second save() must not write any output"
+    wb.save(str(good_path))
+    assert load_workbook(good_path).active["A1"].value == "hello"

--- a/tests/test_openpyxl_compat_oracle.py
+++ b/tests/test_openpyxl_compat_oracle.py
@@ -177,6 +177,7 @@ def _probe_workbook_load_read_only(tmp_path: Path) -> None:
 
 @_register("workbook_save_basic")
 def _probe_workbook_save_basic(tmp_path: Path) -> None:
+    import openpyxl
     import wolfxl
 
     wb = wolfxl.Workbook()
@@ -184,6 +185,12 @@ def _probe_workbook_save_basic(tmp_path: Path) -> None:
     out = tmp_path / "save_basic.xlsx"
     wb.save(out)
     assert out.exists() and out.stat().st_size > 0
+    wb.active["B1"] = 84
+    second = tmp_path / "save_basic_again.xlsx"
+    wb.save(second)
+    reloaded = openpyxl.load_workbook(second)
+    assert reloaded.active["A1"].value == 42
+    assert reloaded.active["B1"].value == 84
 
 
 @_register("workbook_sheet_access")
@@ -206,6 +213,30 @@ def _probe_workbook_create_sheet(tmp_path: Path) -> None:
     ws = wb.create_sheet(title="Extra")
     assert "Extra" in wb.sheetnames
     assert wb["Extra"] is ws
+
+
+@_register("workbook_rename_sheet_modify")
+def _probe_workbook_rename_sheet_modify(tmp_path: Path) -> None:
+    import openpyxl
+    import wolfxl
+
+    src = tmp_path / "rename_modify.xlsx"
+    seed = openpyxl.Workbook()
+    seed.active.title = "Old"
+    seed.active["A1"] = "before"
+    seed.save(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    ws = wb["Old"]
+    ws.title = "New"
+    ws["B1"] = "after"
+    wb.save(src)
+    wb.close()
+
+    reloaded = openpyxl.load_workbook(src)
+    assert reloaded.sheetnames == ["New"]
+    assert reloaded["New"]["A1"].value == "before"
+    assert reloaded["New"]["B1"].value == "after"
 
 
 @_register("workbook_copy_worksheet")
@@ -604,6 +635,14 @@ def _probe_charts_chartsheet(tmp_path: Path) -> None:
     assert op.sheetnames == ["Sheet", "ChartOnly"]
     assert len(op.chartsheets) == 1
     assert op.chartsheets[0].title == "ChartOnly"
+
+    opened = wolfxl.load_workbook(out)
+    assert opened.sheetnames == ["Sheet", "ChartOnly"]
+    assert [ws.title for ws in opened.worksheets] == ["Sheet"]
+    assert [cs.title for cs in opened.chartsheets] == ["ChartOnly"]
+    assert opened["ChartOnly"] is opened.chartsheets[0]
+    assert len(opened.chartsheets[0]._charts) == 1  # noqa: SLF001
+
     with zipfile.ZipFile(out) as zf:
         assert "xl/chartsheets/sheet1.xml" in zf.namelist()
         assert "/relationships/chartsheet" in zf.read(

--- a/tests/test_openpyxl_compat_oracle.py
+++ b/tests/test_openpyxl_compat_oracle.py
@@ -34,6 +34,7 @@ the baseline number is meaningful and reproducible without network.
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import re
@@ -213,6 +214,48 @@ def _probe_workbook_create_sheet(tmp_path: Path) -> None:
     ws = wb.create_sheet(title="Extra")
     assert "Extra" in wb.sheetnames
     assert wb["Extra"] is ws
+
+
+@_register("workbook_create_sheet_modify")
+def _probe_workbook_create_sheet_modify(tmp_path: Path) -> None:
+    import openpyxl
+    import wolfxl
+
+    src = tmp_path / "create_sheet_modify_src.xlsx"
+    seed = openpyxl.Workbook()
+    seed.active.title = "First"
+    seed.create_sheet("Second")
+    seed.save(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    ws = wb.create_sheet("Inserted", index=1)
+    ws["A1"] = "created"
+    out = tmp_path / "create_sheet_modify.xlsx"
+    wb.save(out)
+
+    rt = openpyxl.load_workbook(out)
+    assert rt.sheetnames == ["First", "Inserted", "Second"]
+    assert rt["Inserted"]["A1"].value == "created"
+
+
+@_register("workbook_remove_sheet_modify")
+def _probe_workbook_remove_sheet_modify(tmp_path: Path) -> None:
+    import openpyxl
+    import wolfxl
+
+    src = tmp_path / "remove_sheet_modify_src.xlsx"
+    seed = openpyxl.Workbook()
+    seed.active.title = "Keep"
+    seed.create_sheet("Drop")
+    seed.save(src)
+
+    wb = wolfxl.load_workbook(src, modify=True)
+    wb.remove(wb["Drop"])
+    out = tmp_path / "remove_sheet_modify.xlsx"
+    wb.save(out)
+
+    rt = openpyxl.load_workbook(out)
+    assert rt.sheetnames == ["Keep"]
 
 
 @_register("workbook_rename_sheet_modify")
@@ -596,6 +639,7 @@ def _probe_charts_surface_stock_projected(tmp_path: Path) -> None:
 
 @_register("charts_add_remove_replace")
 def _probe_charts_add_remove_replace(tmp_path: Path) -> None:
+    import openpyxl as _opx
     import wolfxl
     from wolfxl.chart import BarChart, Reference
 
@@ -610,6 +654,27 @@ def _probe_charts_add_remove_replace(tmp_path: Path) -> None:
     ws.add_chart(chart, "D2")
     assert hasattr(ws, "remove_chart")
     ws.remove_chart(chart)
+
+    src = tmp_path / "source_chart.xlsx"
+    op_wb = _opx.Workbook()
+    op_ws = op_wb.active
+    op_ws.title = "Data"
+    for row in [["x", "y"], [1, 10], [2, 20]]:
+        op_ws.append(row)
+    op_chart = _opx.chart.BarChart()
+    op_chart.title = "Original"
+    op_chart.add_data(
+        _opx.chart.Reference(op_ws, min_col=2, min_row=1, max_row=3),
+        titles_from_data=True,
+    )
+    op_ws.add_chart(op_chart, "D2")
+    op_wb.save(src)
+
+    loaded = wolfxl.load_workbook(src, modify=True)
+    loaded["Data"]._charts[0].title = "Changed"
+    out = tmp_path / "source_chart_title.xlsx"
+    loaded.save(out)
+    assert "Changed" in _zip_read_text(out, "xl/charts/chart1.xml")
 
 
 @_register("charts_chartsheet")
@@ -1340,23 +1405,26 @@ def _probe_protection_workbook(tmp_path: Path) -> None:
 
 @_register("external_links_collection")
 def _probe_external_links_collection(tmp_path: Path) -> None:
-    """Workbook-level external link collection. Tracked under G18 (S6).
-
-    The probe asserts that round-tripping a workbook with an external-link
-    formula preserves the ``xl/externalLinks/`` parts. Today wolfxl preserves
-    the parts on modify-save but does not expose a Python collection;
-    ``wb._external_links`` (or equivalent public surface) is what S6 ships.
-    """
     import wolfxl
 
-    wb = wolfxl.Workbook()
-    wb.active["A1"] = "='[ext.xlsx]Sheet1'!$A$1"
-    out = tmp_path / "ext.xlsx"
-    wb.save(out)
+    fixture = REPO_ROOT / "tests" / "fixtures" / "external_links_basic.xlsx"
+    data = fixture.read_bytes()
 
-    wb2 = wolfxl.load_workbook(out)
-    links = getattr(wb2, "_external_links", None) or getattr(wb2, "external_links", None)
-    assert links is not None and len(links) >= 0  # surface must exist
+    wb = wolfxl.load_workbook(fixture)
+    assert len(wb._external_links) == 1
+    assert wb._external_links[0].target == "ext.xlsx"
+
+    assert wolfxl.load_workbook(fixture, keep_links=False)._external_links == []
+
+    from_bytes = wolfxl.load_workbook(io.BytesIO(data))
+    assert len(from_bytes._external_links) == 1
+
+    stripped = tmp_path / "external_links_stripped.xlsx"
+    modify = wolfxl.load_workbook(fixture, modify=True, keep_links=False)
+    modify.save(stripped)
+    entries = _zip_listing(stripped)
+    assert not any(name.startswith("xl/externalLinks/") for name in entries)
+    assert "<externalReferences>" not in _zip_read_text(stripped, "xl/workbook.xml")
 
 
 @_register("external_links_authoring")

--- a/tests/test_openpyxl_compat_oracle.py
+++ b/tests/test_openpyxl_compat_oracle.py
@@ -581,6 +581,36 @@ def _probe_charts_add_remove_replace(tmp_path: Path) -> None:
     ws.remove_chart(chart)
 
 
+@_register("charts_chartsheet")
+def _probe_charts_chartsheet(tmp_path: Path) -> None:
+    import openpyxl as _opx
+    import wolfxl
+    from wolfxl.chart import BarChart, Reference
+
+    wb = wolfxl.Workbook()
+    ws = wb.active
+    for row in [["x", "y"], [1, 10], [2, 20]]:
+        ws.append(row)
+
+    chart = BarChart()
+    chart.add_data(Reference(ws, min_col=2, min_row=1, max_row=3), titles_from_data=True)
+    chart.set_categories(Reference(ws, min_col=1, min_row=2, max_row=3))
+    cs = wb.create_chartsheet("ChartOnly")
+    cs.add_chart(chart)
+    out = tmp_path / "chartsheet.xlsx"
+    wb.save(out)
+
+    op = _opx.load_workbook(out)
+    assert op.sheetnames == ["Sheet", "ChartOnly"]
+    assert len(op.chartsheets) == 1
+    assert op.chartsheets[0].title == "ChartOnly"
+    with zipfile.ZipFile(out) as zf:
+        assert "xl/chartsheets/sheet1.xml" in zf.namelist()
+        assert "/relationships/chartsheet" in zf.read(
+            "xl/_rels/workbook.xml.rels"
+        ).decode()
+
+
 @_register("charts_combination")
 def _probe_charts_combination(tmp_path: Path) -> None:
     import openpyxl as _opx

--- a/tests/test_openpyxl_compat_oracle.py
+++ b/tests/test_openpyxl_compat_oracle.py
@@ -214,6 +214,8 @@ def _probe_workbook_create_sheet(tmp_path: Path) -> None:
     ws = wb.create_sheet(title="Extra")
     assert "Extra" in wb.sheetnames
     assert wb["Extra"] is ws
+    assert wb.create_sheet().title == "Sheet1"
+    assert wb.create_sheet("Extra").title == "Extra1"
 
 
 @_register("workbook_create_sheet_modify")
@@ -230,12 +232,16 @@ def _probe_workbook_create_sheet_modify(tmp_path: Path) -> None:
     wb = wolfxl.load_workbook(src, modify=True)
     ws = wb.create_sheet("Inserted", index=1)
     ws["A1"] = "created"
+    assert wb.create_sheet().title == "Sheet"
+    transient = wb.create_sheet("Transient")
+    wb.remove(transient)
     out = tmp_path / "create_sheet_modify.xlsx"
     wb.save(out)
 
     rt = openpyxl.load_workbook(out)
-    assert rt.sheetnames == ["First", "Inserted", "Second"]
+    assert rt.sheetnames == ["First", "Inserted", "Second", "Sheet"]
     assert rt["Inserted"]["A1"].value == "created"
+    assert "Transient" not in rt.sheetnames
 
 
 @_register("workbook_remove_sheet_modify")

--- a/tests/test_workbook_compat_t0.py
+++ b/tests/test_workbook_compat_t0.py
@@ -35,6 +35,17 @@ def test_index_returns_sheet_position() -> None:
     assert wb.get_sheet_names() == wb.sheetnames
 
 
+def test_create_sheet_auto_generates_duplicate_names_like_openpyxl() -> None:
+    wb = wolfxl.Workbook()
+
+    assert wb.create_sheet().title == "Sheet1"
+    assert wb.create_sheet("Sheet").title == "Sheet2"
+    assert wb.create_sheet("Data").title == "Data"
+    assert wb.create_sheet("data").title == "data1"
+    assert wb.create_sheet("Data1").title == "Data11"
+    assert wb.create_sheet("").title == "Sheet3"
+
+
 def test_create_named_range_alias() -> None:
     wb = wolfxl.Workbook()
     ws = wb.active

--- a/tests/test_workbook_compat_t0.py
+++ b/tests/test_workbook_compat_t0.py
@@ -80,10 +80,14 @@ def test_add_named_style_persists_name_on_save(tmp_path: Path) -> None:
     assert rt.style_names == ["Normal", "Metric"]
 
 
-def test_create_chartsheet_raises_clear_error() -> None:
+def test_create_chartsheet_returns_chartsheet() -> None:
     wb = wolfxl.Workbook()
-    with pytest.raises(NotImplementedError, match="create_chartsheet"):
-        wb.create_chartsheet("Chart")
+    cs = wb.create_chartsheet("Chart")
+    assert cs.title == "Chart"
+    assert wb["Chart"] is cs
+    assert wb.chartsheets == [cs]
+    assert wb.sheetnames == ["Sheet", "Chart"]
+    assert wb.worksheets == [wb["Sheet"]]
 
 
 def test_read_only_false_for_write_mode() -> None:

--- a/tests/vendored_openpyxl_allowlist.json
+++ b/tests/vendored_openpyxl_allowlist.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "entries": [],
+  "categories": [
+    "openpyxl_internal",
+    "unsupported_out_of_scope",
+    "infra_mismatch",
+    "true_wolfxl_gap"
+  ]
+}


### PR DESCRIPTION
## Summary
- add modify-mode worksheet create/remove support, including workbook relationships, content types, tab order, sheet targets, defined-name localSheetId handling, and worksheet subgraph cleanup
- persist source-loaded worksheet chart remove/replace/title edits through a focused post-save OOXML rewrite
- honor keep_links=False for external links and parse external-link metadata from file-like/bytes-backed XLSX sources
- add optional non-network openpyxl corpus runner and refresh the compatibility oracle/matrix rows

## Verification
- uv run maturin develop
- uv run --no-sync python -m pytest tests/ -q
- cargo test --workspace -q
- uv run --no-sync ruff check python/ tests/ scripts/run_openpyxl_corpus.py
- uv run --no-sync python scripts/render_compat_matrix.py
- git diff --check
- uv run --no-sync python scripts/run_openpyxl_corpus.py --report /tmp/wolfxl-openpyxl-corpus-summary.json
- uv run --no-sync python -m pytest tests/test_move_sheet_modify.py tests/test_external_links.py tests/test_charts_remove.py tests/test_openpyxl_compat_oracle.py -q
- uv run --no-sync python -m pytest tests/test_calcchain_rebuild.py tests/test_pivot_slicers.py tests/test_advanced_pivots_save_smoke.py tests/test_openpyxl_dynamic_surface.py -q
- cargo check -q
- cargo fmt --check