### PR TITLE
Sprint 7: ratchet Windows save and OOXML safety seams

### DIFF
--- a/tests/test_atomic_save_safety.py
+++ b/tests/test_atomic_save_safety.py
@@ -25,3 +25,37 @@ def test_failed_native_save_preserves_existing_target(
         replacement.save(target)
 
     assert target.read_bytes() == before
+
+
+def test_modify_save_in_place_replaces_existing_target(tmp_path: Path) -> None:
+    target = tmp_path / "in_place.xlsx"
+
+    wb = wolfxl.Workbook()
+    wb.active["A1"] = "before"
+    wb.save(target)
+    wb.close()
+
+    loaded = wolfxl.load_workbook(target, modify=True)
+    loaded.active["A1"] = "after"
+    loaded.save(target)
+    loaded.close()
+
+    reloaded = wolfxl.load_workbook(target, read_only=True)
+    assert next(reloaded.active.iter_rows(values_only=True))[0] == "after"
+
+
+def test_native_save_over_existing_target_succeeds(tmp_path: Path) -> None:
+    target = tmp_path / "overwrite.xlsx"
+
+    first = wolfxl.Workbook()
+    first.active["A1"] = "first"
+    first.save(target)
+    first.close()
+
+    second = wolfxl.Workbook()
+    second.active["A1"] = "second"
+    second.save(target)
+    second.close()
+
+    reloaded = wolfxl.load_workbook(target, read_only=True)
+    assert next(reloaded.active.iter_rows(values_only=True))[0] == "second"

--- a/tests/test_charts_remove.py
+++ b/tests/test_charts_remove.py
@@ -71,6 +71,34 @@ def _build_workbook_with_two_openpyxl_charts(path: Path) -> Path:
     return path
 
 
+def _inject_shared_chart_dependencies(path: Path) -> None:
+    rels_xml = (
+        b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        b'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        b'<Relationship Id="rId1" '
+        b'Type="http://schemas.microsoft.com/office/2011/relationships/chartStyle" '
+        b'Target="style1.xml"/>'
+        b'<Relationship Id="rId2" '
+        b'Type="http://schemas.microsoft.com/office/2011/relationships/chartColorStyle" '
+        b'Target="colors1.xml"/>'
+        b"</Relationships>"
+    )
+    shared_parts = {
+        "xl/charts/_rels/chart1.xml.rels": rels_xml,
+        "xl/charts/_rels/chart2.xml.rels": rels_xml,
+        "xl/charts/style1.xml": b"<c:styleSheet/>",
+        "xl/charts/colors1.xml": b"<c:colorStyle/>",
+    }
+    parts: dict[str, bytes] = {}
+    with zipfile.ZipFile(path, "r") as zf:
+        for name in zf.namelist():
+            parts[name] = zf.read(name)
+    parts.update(shared_parts)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in parts.items():
+            zf.writestr(name, data)
+
+
 def _build_workbook_with_image_and_chart(path: Path) -> Path:
     openpyxl = pytest.importorskip("openpyxl")
     from openpyxl.chart import BarChart, Reference
@@ -373,6 +401,35 @@ def test_modify_remove_one_loaded_chart_keeps_second(tmp_path: Path) -> None:
         drawing_xml = zf.read("xl/drawings/drawing1.xml").decode()
     assert len(chart_xmls) == 1
     assert drawing_xml.count("<c:chart") == 1
+
+
+def test_modify_remove_one_loaded_chart_preserves_shared_chart_dependencies(
+    tmp_path: Path,
+) -> None:
+    import wolfxl
+
+    base = _build_workbook_with_two_openpyxl_charts(tmp_path / "shared_chart_deps.xlsx")
+    _inject_shared_chart_dependencies(base)
+
+    wb = wolfxl.load_workbook(base, modify=True)
+    ws = wb.active
+    assert len(ws._charts) == 2
+    ws.remove_chart(ws._charts[0])
+    out = tmp_path / "shared_chart_deps_removed.xlsx"
+    wb.save(out)
+
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+        chart2_rels = zf.read("xl/charts/_rels/chart2.xml.rels").decode("utf-8")
+
+    assert "xl/charts/chart1.xml" not in names
+    assert "xl/charts/_rels/chart1.xml.rels" not in names
+    assert "xl/charts/chart2.xml" in names
+    assert "xl/charts/_rels/chart2.xml.rels" in names
+    assert "xl/charts/style1.xml" in names
+    assert "xl/charts/colors1.xml" in names
+    assert "chartStyle" in chart2_rels
+    assert "chartColorStyle" in chart2_rels
 
 
 def test_modify_remove_loaded_chart_from_mixed_drawing_keeps_image(tmp_path: Path) -> None:

--- a/tests/test_external_links.py
+++ b/tests/test_external_links.py
@@ -328,6 +328,34 @@ def test_modify_mode_keep_links_false_drops_multiple_external_links(
     assert "externalLink+xml" not in content_types
 
 
+def test_keep_links_false_composes_with_sheet_create_rels(tmp_path: Path) -> None:
+    fixture = _build_two_external_links_fixture(tmp_path / "source_with_links.xlsx")
+    wb = wolfxl.load_workbook(fixture, modify=True, keep_links=False)
+    added = wb.create_sheet("Added")
+    added["A1"] = "kept"
+    out = tmp_path / "links_dropped_sheet_added.xlsx"
+    wb.save(out)
+    wb.close()
+
+    with zipfile.ZipFile(out, "r") as zf:
+        names = set(zf.namelist())
+        workbook_xml = zf.read("xl/workbook.xml").decode("utf-8")
+        workbook_rels = zf.read("xl/_rels/workbook.xml.rels").decode("utf-8")
+        content_types = zf.read("[Content_Types].xml").decode("utf-8")
+
+    assert not any(name.startswith("xl/externalLinks/") for name in names)
+    assert "externalReferences" not in workbook_xml
+    assert "/relationships/externalLink" not in workbook_rels
+    assert "externalLink+xml" not in content_types
+    assert 'name="Added"' in workbook_xml
+    assert "worksheets/sheet2.xml" in workbook_rels
+    assert "xl/worksheets/sheet2.xml" in names
+
+    reloaded = wolfxl.load_workbook(out, read_only=True)
+    assert reloaded["Added"]["A1"].value == "kept"
+    assert reloaded._external_links == []
+
+
 def test_external_links_alias_is_same_list(fixture_path: Path) -> None:
     """``wb.external_links`` and ``wb._external_links`` return the same list.
 

--- a/tests/test_ooxml_package_safety.py
+++ b/tests/test_ooxml_package_safety.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 import wolfxl
-from wolfxl._zip_safety import _validate_info
+from wolfxl._zip_safety import _validate_info, validate_zipfile
 
 
 def _write_zip(path: Path, entries: dict[str, bytes]) -> None:
@@ -53,4 +53,59 @@ def test_rejects_unsafe_part_path(tmp_path: Path) -> None:
     _write_zip(path, {"../xl/workbook.xml": b"<workbook/>"})
 
     with pytest.raises(Exception, match="unsafe OOXML package part path"):
+        wolfxl.load_workbook(path)
+
+
+@pytest.mark.parametrize(
+    "part_name",
+    [
+        "/xl/workbook.xml",
+        r"xl\workbook.xml",
+        "xl/C:/workbook.xml",
+    ],
+)
+def test_rejects_absolute_windows_or_backslash_part_paths(
+    tmp_path: Path, part_name: str
+) -> None:
+    path = tmp_path / "unsafe-paths.xlsx"
+    _write_zip(path, {part_name: b"<workbook/>"})
+
+    with pytest.raises(Exception, match="unsafe OOXML package part path"):
+        wolfxl.load_workbook(path)
+
+
+def test_rejects_duplicate_zip_entry_names(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.xlsx"
+    wb = wolfxl.Workbook()
+    wb.active["A1"] = "duplicate"
+    wb.save(path)
+    with zipfile.ZipFile(path, "a", compression=zipfile.ZIP_DEFLATED) as zf:
+        with pytest.warns(UserWarning, match="Duplicate name"):
+            zf.writestr("xl/workbook.xml", b"<workbook/>")
+
+    with zipfile.ZipFile(path) as zf:
+        with pytest.raises(Exception, match="duplicate ZIP entry"):
+            validate_zipfile(zf)
+
+
+def test_rejects_too_many_zip_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "too-many.xlsx"
+    _write_zip(path, {"xl/workbook.xml": b"<workbook/>", "xl/styles.xml": b"<styleSheet/>"})
+    monkeypatch.setenv("WOLFXL_MAX_ZIP_ENTRIES", "1")
+
+    with pytest.raises(Exception, match="too many ZIP entries"):
+        wolfxl.load_workbook(path)
+
+
+def test_rejects_total_uncompressed_zip_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "too-large-total.xlsx"
+    _write_zip(path, {"xl/workbook.xml": b"x" * 8, "xl/styles.xml": b"x" * 8})
+    monkeypatch.setenv("WOLFXL_MAX_ZIP_ENTRY_BYTES", "100")
+    monkeypatch.setenv("WOLFXL_MAX_ZIP_TOTAL_BYTES", "10")
+
+    with pytest.raises(Exception, match="OOXML package is too large"):
         wolfxl.load_workbook(path)

--- a/tests/test_ooxml_package_safety.py
+++ b/tests/test_ooxml_package_safety.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 import wolfxl
-from wolfxl._zip_safety import _validate_info, validate_zipfile
+from wolfxl._zip_safety import _validate_info, _validate_part_name, validate_zipfile
 
 
 def _write_zip(path: Path, entries: dict[str, bytes]) -> None:
@@ -65,13 +65,10 @@ def test_rejects_unsafe_part_path(tmp_path: Path) -> None:
     ],
 )
 def test_rejects_absolute_windows_or_backslash_part_paths(
-    tmp_path: Path, part_name: str
+    part_name: str,
 ) -> None:
-    path = tmp_path / "unsafe-paths.xlsx"
-    _write_zip(path, {part_name: b"<workbook/>"})
-
-    with pytest.raises(Exception, match="unsafe OOXML package part path"):
-        wolfxl.load_workbook(path)
+    with pytest.raises(ValueError, match="unsafe OOXML package part path"):
+        _validate_part_name(part_name)
 
 
 def test_rejects_duplicate_zip_entry_names(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds Windows-oriented atomic-save overwrite and modify-save-in-place regression tests.
- Expands OOXML ZIP safety ratchets for unsafe paths, duplicate entries, entry count, and total uncompressed size limits.
- Adds a keep_links=False composition test that drops external links while preserving newly created worksheet rels.
- Adds a shared chart dependency ratchet so removing one source chart preserves dependency parts still referenced by a sibling chart.

## Validation
- `uv run pytest tests/test_atomic_save_safety.py tests/test_ooxml_package_safety.py tests/test_external_links.py::test_keep_links_false_composes_with_sheet_create_rels tests/test_charts_remove.py::test_modify_remove_one_loaded_chart_preserves_shared_chart_dependencies -q` — 15 passed
- `cargo fmt --check && cargo check && cargo test` — 255 passed
- `uvx ruff check $(git ls-files '*.py')` — passed
- `uv run maturin develop --quiet` — passed
- `uv run pytest -q` — 2702 passed, 42 skipped

## Risk Notes
- Test-only sprint; no production implementation changes.
- New fixtures mutate ZIP internals directly to lock in PR-review seams without depending on Excel authoring behavior.
