### PR TITLE
Guard OOXML fidelity completion claim

### DIFF
--- a/Plans/real-world-excel-fidelity-gap-discovery.md
+++ b/Plans/real-world-excel-fidelity-gap-discovery.md
@@ -491,6 +491,7 @@ Prompt-to-artifact checklist:
 | Whole-pack preservation under common edits | `tests/test_external_oracle_preservation.py` | `198 passed` after the latest changes | Strong pinned-pack regression gate |
 | Combined all-evidence gate | `scripts/audit_ooxml_fidelity_coverage.py --strict --require-render --require-intentional-render --require-app --require-intentional-app` | Latest regenerated report `/tmp/wolfxl-coverage-all-evidence-current-code-plus-excel-powerpivot.json`: `ready=True`, 22 fixtures, 13 surfaces, 5 mutation reports, 6 render reports, 9 app reports; external-link relationship edges now accept `retarget_external_links` as a structural mutation and clear on three retargeted external-link fixtures with intentional Microsoft Excel app-open evidence | Strong current-state gate |
 | Evidence bundle freshness | `scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict` | Latest run `/tmp/wolfxl-current-evidence-bundle-audit-20260509-ui-interaction-gate.json`: `ready=True`, 83 report artifacts verified, 83 producer commands recorded, 0 issues | Stronger provenance over the current generated evidence set; still dependent on generated reports being refreshed when fixtures or gates change |
+| Completion claim guard | `scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence` | Latest run `/tmp/wolfxl-completion-claim-audit-20260509.json`: `current_supported_claim_ready=True`, `exhaustive_claim_ready=False`, `missing_requirement_count=4`, and current bundle ready | Prevents the supported current claim from being silently upgraded into the exhaustive "no real-world Excel fidelity gaps" claim |
 
 Current conclusion:
 
@@ -501,6 +502,10 @@ Current conclusion:
   structural intentional-edit Excel-rendered smoke, broader click-level
   slicer/date-range variants, and more adversarial mutations than
   the current pack can provide.
+- The machine-readable completion claim guard now encodes that boundary:
+  `scripts/audit_ooxml_completion_claim.py --strict-current-evidence` passes
+  for the current supported claim, while `--strict-claim` intentionally fails
+  until the open requirements above are closed.
 
 Next evidence slices before declaring a higher-confidence "no known gaps":
 

--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Audit whether the OOXML fidelity evidence supports the broad completion claim."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import audit_ooxml_evidence_bundle  # noqa: E402
+
+OBJECTIVE = "no real-world Excel fidelity gaps"
+EXHAUSTIVE_CLAIM = "no_real_world_excel_fidelity_gaps"
+CURRENT_SUPPORTED_CLAIM = (
+    "no known fidelity gap in the currently pinned and classified real-world OOXML surface"
+)
+
+OPEN_REQUIREMENTS = (
+    {
+        "id": "broader_real_world_corpus_diversity",
+        "status": "open",
+        "reason": (
+            "The current evidence spans pinned and sidecar corpora, but not a broad "
+            "customer-scale or random real-world Excel corpus."
+        ),
+    },
+    {
+        "id": "feature_specific_intentional_render_equivalence",
+        "status": "open",
+        "reason": (
+            "Intentional Microsoft Excel render checks prove renderability for selected "
+            "edits, not semantic visual equivalence for every high-risk feature edit."
+        ),
+    },
+    {
+        "id": "broader_click_level_interaction_variants",
+        "status": "open",
+        "reason": (
+            "Targeted UI-interaction evidence exists, but broader slicer, timeline, "
+            "embedded-control, and prompt variants remain unexhausted."
+        ),
+    },
+    {
+        "id": "future_surface_exhaustiveness",
+        "status": "open",
+        "reason": (
+            "Gap radar can catch newly seen OOXML part families and extension URIs; it "
+            "cannot prove that no unseen real-world Excel surface exists."
+        ),
+    },
+)
+
+
+def audit_completion_claim(bundle_path: Path) -> dict:
+    bundle_audit = audit_ooxml_evidence_bundle.audit_bundle(bundle_path)
+    bundle_ready = bool(bundle_audit["ready"])
+    criteria = [
+        {
+            "id": "current_evidence_bundle_ready",
+            "status": "satisfied" if bundle_ready else "missing",
+            "evidence": {
+                "manifest": str(bundle_path),
+                "ready": bundle_ready,
+                "report_count": bundle_audit["report_count"],
+                "producer_count": bundle_audit["producer_count"],
+                "issue_count": bundle_audit["issue_count"],
+            },
+        },
+        *OPEN_REQUIREMENTS,
+    ]
+    missing = [
+        criterion
+        for criterion in criteria
+        if criterion["status"] in {"missing", "open", "partial"}
+    ]
+    return {
+        "objective": OBJECTIVE,
+        "exhaustive_claim": EXHAUSTIVE_CLAIM,
+        "exhaustive_claim_ready": False,
+        "current_supported_claim": CURRENT_SUPPORTED_CLAIM,
+        "current_supported_claim_ready": bundle_ready,
+        "criteria": criteria,
+        "missing_requirement_count": len(missing),
+        "missing_requirements": missing,
+        "bundle_audit": {
+            "ready": bundle_ready,
+            "report_count": bundle_audit["report_count"],
+            "producer_count": bundle_audit["producer_count"],
+            "issue_count": bundle_audit["issue_count"],
+            "issues": bundle_audit["issues"],
+        },
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "bundle",
+        type=Path,
+        nargs="?",
+        default=Path("Plans/ooxml-current-evidence-bundle.json"),
+        help="Pinned evidence bundle manifest to audit.",
+    )
+    parser.add_argument(
+        "--strict-current-evidence",
+        action="store_true",
+        help="Exit non-zero when the pinned current evidence bundle is stale.",
+    )
+    parser.add_argument(
+        "--strict-claim",
+        action="store_true",
+        help="Exit non-zero unless the exhaustive no-gap claim is supported.",
+    )
+    args = parser.parse_args(argv)
+    report = audit_completion_claim(args.bundle)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.strict_claim and not report["exhaustive_claim_ready"]:
+        return 1
+    if args.strict_current_evidence and not report["current_supported_claim_ready"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_completion_module() -> ModuleType:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "audit_ooxml_completion_claim.py"
+    spec = importlib.util.spec_from_file_location("audit_ooxml_completion_claim", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+completion = _load_completion_module()
+
+
+def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_bundle_manifest(tmp_path, ready=True)
+
+    report = completion.audit_completion_claim(manifest)
+
+    assert report["objective"] == "no real-world Excel fidelity gaps"
+    assert report["current_supported_claim_ready"] is True
+    assert report["exhaustive_claim_ready"] is False
+    assert report["bundle_audit"]["ready"] is True
+    assert report["missing_requirement_count"] == 4
+    assert {
+        requirement["id"] for requirement in report["missing_requirements"]
+    } == {
+        "broader_real_world_corpus_diversity",
+        "feature_specific_intentional_render_equivalence",
+        "broader_click_level_interaction_variants",
+        "future_surface_exhaustiveness",
+    }
+
+
+def test_completion_claim_audit_blocks_current_claim_when_bundle_is_stale(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_bundle_manifest(tmp_path, ready=False)
+
+    report = completion.audit_completion_claim(manifest)
+
+    assert report["current_supported_claim_ready"] is False
+    assert report["exhaustive_claim_ready"] is False
+    assert report["bundle_audit"]["issue_count"] == 1
+    assert report["missing_requirements"][0]["id"] == "current_evidence_bundle_ready"
+
+
+def test_completion_claim_strict_current_evidence_only_checks_bundle_freshness(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    ready_manifest = _write_bundle_manifest(tmp_path / "ready", ready=True)
+    stale_manifest = _write_bundle_manifest(tmp_path / "stale", ready=False)
+
+    ready_code = completion.main([str(ready_manifest), "--strict-current-evidence"])
+    ready_payload = json.loads(capsys.readouterr().out)
+    stale_code = completion.main([str(stale_manifest), "--strict-current-evidence"])
+    stale_payload = json.loads(capsys.readouterr().out)
+
+    assert ready_code == 0
+    assert ready_payload["current_supported_claim_ready"] is True
+    assert ready_payload["exhaustive_claim_ready"] is False
+    assert stale_code == 1
+    assert stale_payload["current_supported_claim_ready"] is False
+
+
+def test_completion_claim_strict_claim_fails_until_open_requirements_close(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    manifest = _write_bundle_manifest(tmp_path, ready=True)
+
+    code = completion.main([str(manifest), "--strict-claim"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert code == 1
+    assert payload["current_supported_claim_ready"] is True
+    assert payload["exhaustive_claim_ready"] is False
+
+
+def _write_bundle_manifest(tmp_path: Path, *, ready: bool) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps({"ready": ready}))
+    manifest = tmp_path / "bundle.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "reports": [
+                    {
+                        "name": "current",
+                        "path": str(report_path),
+                        "producer": "uv run --no-sync python scripts/example.py --strict",
+                        "expect": [{"path": "ready", "equals": True}],
+                    }
+                ]
+            }
+        )
+    )
+    return manifest


### PR DESCRIPTION
## Summary
- add a machine-readable audit for the broad OOXML fidelity completion claim
- keep the current supported claim separate from the exhaustive no-real-world-gaps claim
- document the new guard in the fidelity gap discovery plan

## Verification
- uv run --no-sync --with pytest python -m pytest tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q
- uv run --no-sync ruff check scripts/audit_ooxml_completion_claim.py tests/test_ooxml_completion_claim.py
- git diff --check
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence
