### PR TITLE
Clarify Excel unsupported app-smoke counts

### DIFF
--- a/scripts/run_ooxml_app_smoke.py
+++ b/scripts/run_ooxml_app_smoke.py
@@ -47,12 +47,16 @@ PASSING_STATUSES = {"passed", "skipped", "expected_app_unsupported"}
 SOURCE_MUTATION = "source"
 EXCEL_REPAIR_MARKER = "Excel repair/error dialog while opening:"
 EXCEL_UNSUPPORTED_CONTENT_MARKER = "Excel unsupported-content dialog while opening:"
-UNSUPPORTED_CONTENT_KEYWORDS = (
+UNSUPPORTED_CONTENT_PROMPT_KEYWORDS = (
     "isn't supported in this version of excel",
     "is not supported in this version of excel",
     "unsupported content",
-    "powerview",
 )
+UNSUPPORTED_CONTENT_FEATURE_KEYWORDS = (
+    "powerview",
+    "power view",
+)
+UNSUPPORTED_CONTENT_ACTION_KEYWORDS = ("open as read-only",)
 UNSUPPORTED_CONTENT_DISMISS_BUTTONS = ("Cancel", "OK", "Close")
 
 
@@ -176,6 +180,18 @@ def _write_report(
     aborted: bool,
     abort_reason: str | None,
 ) -> dict:
+    clean_pass_count = sum(1 for result in results if result.status == "passed")
+    skipped_count = sum(1 for result in results if result.status == "skipped")
+    expected_app_unsupported_count = sum(
+        1 for result in results if result.status == "expected_app_unsupported"
+    )
+    unexpected_app_unsupported_count = sum(
+        1
+        for result in results
+        if result.status not in PASSING_STATUSES
+        and EXCEL_UNSUPPORTED_CONTENT_MARKER in result.message
+    )
+    non_clean_count = len(results) - clean_pass_count
     report = {
         "fixture_dir": str(fixture_dir),
         "output_dir": str(output_dir.resolve()),
@@ -185,6 +201,11 @@ def _write_report(
         "abort_reason": abort_reason,
         "result_count": len(results),
         "failure_count": sum(1 for result in results if result.status not in PASSING_STATUSES),
+        "clean_pass_count": clean_pass_count,
+        "skipped_count": skipped_count,
+        "expected_app_unsupported_count": expected_app_unsupported_count,
+        "unexpected_app_unsupported_count": unexpected_app_unsupported_count,
+        "non_clean_count": non_clean_count,
         "results": [asdict(result) for result in results],
     }
     (output_dir / "app-smoke-report.json").write_text(json.dumps(report, indent=2, sort_keys=True))
@@ -297,7 +318,9 @@ def _smoke_excel(
             timeout,
         )
     except subprocess.TimeoutExpired as exc:
+        _dismiss_excel_unsupported_content_dialogs()
         _close_excel_best_effort()
+        _quit_excel_best_effort()
         return AppSmokeResult(
             src.name,
             SOURCE_MUTATION,
@@ -307,6 +330,7 @@ def _smoke_excel(
             f"timeout after {timeout}s: {str(exc)[:500]}",
         )
     except RuntimeError as exc:
+        _dismiss_excel_unsupported_content_dialogs()
         _dismiss_excel_repair_dialogs()
         _close_excel_best_effort()
         _quit_excel_best_effort()
@@ -456,6 +480,7 @@ def _open_excel_with_finder_and_close(src: Path, timeout: int) -> str:
         last_error = dialog
         time.sleep(0.25)
     if launched.poll() is None:
+        _dismiss_excel_unsupported_content_dialogs()
         _dismiss_excel_repair_dialogs()
         _close_excel_best_effort()
         _quit_excel_best_effort()
@@ -491,6 +516,7 @@ def _open_excel_with_finder_and_close(src: Path, timeout: int) -> str:
             return name
         last_error = dialog
         time.sleep(0.5)
+    _dismiss_excel_unsupported_content_dialogs()
     _dismiss_excel_repair_dialogs()
     _close_excel_best_effort()
     _quit_excel_best_effort()
@@ -515,7 +541,15 @@ def _is_excel_recovery_prompt(dialog: str) -> bool:
 
 def _is_excel_unsupported_content_dialog(dialog: str) -> bool:
     dialog_lc = dialog.lower()
-    return any(keyword in dialog_lc for keyword in UNSUPPORTED_CONTENT_KEYWORDS)
+    if any(keyword in dialog_lc for keyword in UNSUPPORTED_CONTENT_PROMPT_KEYWORDS):
+        return True
+    has_unsupported_feature = any(
+        keyword in dialog_lc for keyword in UNSUPPORTED_CONTENT_FEATURE_KEYWORDS
+    )
+    has_read_only_action = any(
+        keyword in dialog_lc for keyword in UNSUPPORTED_CONTENT_ACTION_KEYWORDS
+    )
+    return has_unsupported_feature and has_read_only_action
 
 
 def _kill_process_group_best_effort(proc: subprocess.Popen[str]) -> None:

--- a/tests/test_ooxml_app_smoke.py
+++ b/tests/test_ooxml_app_smoke.py
@@ -213,6 +213,12 @@ def test_excel_unsupported_content_dialog_detection() -> None:
     )
 
     assert smoke_module._is_excel_unsupported_content_dialog(dialog)
+    assert smoke_module._is_excel_unsupported_content_dialog(
+        "buttons=Open as Read-OnlyCancel\ntext=Power View"
+    )
+    assert not smoke_module._is_excel_unsupported_content_dialog(
+        "windows=Power View Dashboard.xlsx"
+    )
     assert not smoke_module._is_excel_unsupported_content_dialog("windows=fixture.xlsx")
 
 
@@ -408,9 +414,53 @@ def test_run_smoke_reports_failure_count(tmp_path: Path, monkeypatch) -> None:
 
     assert report["result_count"] == 1
     assert report["failure_count"] == 1
+    assert report["clean_pass_count"] == 0
+    assert report["skipped_count"] == 0
+    assert report["expected_app_unsupported_count"] == 0
+    assert report["unexpected_app_unsupported_count"] == 0
+    assert report["non_clean_count"] == 1
     assert report["mutations"] == ["source"]
     assert report["aborted"] is False
     assert report["abort_reason"] is None
+    assert (output_dir / "app-smoke-report.json").is_file()
+
+
+def test_run_smoke_reports_expected_unsupported_separately(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    output_dir = tmp_path / "out"
+    fixture_dir.mkdir()
+    fixture = fixture_dir / "powerview.xlsx"
+    _make_fixture(fixture)
+
+    def fake_smoke(src: Path, _output_dir: Path, _timeout: int, **_kwargs):
+        return smoke_module.AppSmokeResult(
+            fixture=src.name,
+            mutation="source",
+            app="excel",
+            status="expected_app_unsupported",
+            output=str(src),
+            message=f"{smoke_module.EXCEL_UNSUPPORTED_CONTENT_MARKER} simulated",
+        )
+
+    monkeypatch.setattr(smoke_module, "_smoke_excel", fake_smoke)
+
+    report = smoke_module.run_smoke(
+        fixture_dir,
+        output_dir,
+        apps=("excel",),
+        timeout=1,
+    )
+
+    assert report["result_count"] == 1
+    assert report["failure_count"] == 0
+    assert report["clean_pass_count"] == 0
+    assert report["skipped_count"] == 0
+    assert report["expected_app_unsupported_count"] == 1
+    assert report["unexpected_app_unsupported_count"] == 0
+    assert report["non_clean_count"] == 1
     assert (output_dir / "app-smoke-report.json").is_file()
 
 
@@ -450,6 +500,10 @@ def test_run_smoke_aborts_after_first_excel_repair_dialog(tmp_path: Path, monkey
     assert "stopped after first Microsoft Excel repair dialog" in report["abort_reason"]
     assert report["result_count"] == 1
     assert report["failure_count"] == 1
+    assert report["unexpected_app_unsupported_count"] == 0
+    assert report["expected_app_unsupported_count"] == 0
+    assert report["clean_pass_count"] == 0
+    assert report["non_clean_count"] == 1
     assert len(seen_sources) == 1
     assert (output_dir / "app-smoke-report.json").is_file()
 
@@ -493,6 +547,10 @@ def test_run_smoke_aborts_after_first_excel_unsupported_content_dialog(
     assert "unsupported-content dialog" in report["abort_reason"]
     assert report["result_count"] == 1
     assert report["failure_count"] == 1
+    assert report["unexpected_app_unsupported_count"] == 1
+    assert report["expected_app_unsupported_count"] == 0
+    assert report["clean_pass_count"] == 0
+    assert report["non_clean_count"] == 1
     assert len(seen_sources) == 1
     assert (output_dir / "app-smoke-report.json").is_file()
 
@@ -563,6 +621,10 @@ def test_run_smoke_can_apply_mutation_before_app_smoke(tmp_path: Path, monkeypat
 
     assert report["result_count"] == 1
     assert report["failure_count"] == 0
+    assert report["clean_pass_count"] == 1
+    assert report["expected_app_unsupported_count"] == 0
+    assert report["unexpected_app_unsupported_count"] == 0
+    assert report["non_clean_count"] == 0
     assert report["mutations"] == ["marker_cell"]
     result = report["results"][0]
     assert result["fixture"] == "simple.xlsx"


### PR DESCRIPTION
## Summary
- add explicit app-smoke report counters for clean passes, skipped runs, expected app-unsupported runs, unexpected unsupported dialogs, and non-clean results
- keep PowerView/Power View unsupported prompts out of clean Excel evidence while preserving expected unsupported classification
- dismiss unsupported-content dialogs on timeout/error cleanup paths

## Verification
- `uv run --with pytest --with openpyxl --with-editable . python -m pytest tests/test_ooxml_app_smoke.py tests/test_ooxml_fidelity_coverage.py -q`
- `uv run --no-sync ruff check scripts/run_ooxml_app_smoke.py tests/test_ooxml_app_smoke.py`
- `git diff --check`
- real PowerPivot sidecar smoke: `failure_count=0`, `clean_pass_count=0`, `expected_app_unsupported_count=1`, `non_clean_count=1`
