### PR TITLE
Pin unsupported Excel evidence counters

### DIFF
--- a/Plans/ooxml-current-evidence-bundle.json
+++ b/Plans/ooxml-current-evidence-bundle.json
@@ -637,6 +637,11 @@
       "expect": [
         {"path": "result_count", "equals": 2},
         {"path": "failure_count", "equals": 0},
+        {"path": "clean_pass_count", "equals": 0},
+        {"path": "skipped_count", "equals": 0},
+        {"path": "expected_app_unsupported_count", "equals": 2},
+        {"path": "unexpected_app_unsupported_count", "equals": 0},
+        {"path": "non_clean_count", "equals": 2},
         {"path": "apps", "equals": ["excel"]},
         {"path": "mutations", "equals": ["source", "marker_cell"]},
         {"path": "results.0.status", "equals": "expected_app_unsupported"},

--- a/Plans/real-world-excel-fidelity-gap-discovery.md
+++ b/Plans/real-world-excel-fidelity-gap-discovery.md
@@ -359,10 +359,11 @@ Gap ledger:
      definitions, three pivot tables, and slicer caches. The sidecar passes
      marker/copy-sheet/move-formula mutation sweep, records expected
      PowerView app-unsupported status for Microsoft Excel source and marker
-     app-smoke, passes sampled Microsoft Excel render-smoke, and passes strict
-     package gap radar with `power_view` recorded as an expected app-unsupported
-     feature after classifying PowerPivot custom-property payloads, theme media
-     relationships, and x15 pivot/slicer extension URIs.
+     app-smoke with zero clean app-open passes, passes sampled Microsoft Excel
+     render-smoke, and passes strict package gap radar with `power_view`
+     recorded as an expected app-unsupported feature after classifying
+     PowerPivot custom-property payloads, theme media relationships, and x15
+     pivot/slicer extension URIs.
    - Latest broader-corpus coverage slice:
      `scripts/audit_ooxml_fidelity_coverage.py --recursive --report` now maps
      nested live-corpus workbooks to mutation evidence and falls back to


### PR DESCRIPTION
## Summary
- make the current evidence bundle assert the new Excel app-smoke unsupported-content counters
- pin the Contoso PowerPivot sidecar as zero clean app-open passes, two expected app-unsupported results, and two non-clean results
- update the fidelity gap-discovery plan wording so the PowerView sidecar cannot be read as clean editable Excel evidence

## Verification
- `uv run --with-editable . python scripts/run_ooxml_app_smoke.py tests/fixtures/powerpivot_variants --output-dir /tmp/wolfxl-app-smoke-excel-powerpivot-contoso-source-marker --app excel --timeout 120 --mutation source --mutation marker_cell`
- `uv run --with-editable . python scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict`
- `uv run --with pytest --with openpyxl --with-editable . python -m pytest tests/test_ooxml_evidence_bundle.py tests/test_ooxml_app_smoke.py -q`
- `uv run --no-sync ruff check scripts/audit_ooxml_evidence_bundle.py tests/test_ooxml_evidence_bundle.py`
- `python3 -m json.tool Plans/ooxml-current-evidence-bundle.json`
- `git diff --check`
