### PR TITLE
Tighten completion claim evidence gates

### DIFF
--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -21,6 +21,28 @@ CURRENT_SUPPORTED_CLAIM = (
     "no known fidelity gap in the currently pinned and classified real-world OOXML surface"
 )
 
+REQUIRED_CURRENT_EVIDENCE_REPORTS = (
+    "combined_all_evidence_gate",
+    "interactive_evidence_gate",
+    "excel_ui_interaction_evidence_gate",
+    "excel_render_full_pack_with_rename_sheet_intentional_coverage_gate",
+    "excel_app_open_full_pack_with_cf_verified_coverage_gate",
+    "external_oracle_corpus_diversity",
+    "external_oracle_gap_radar",
+    "synthgl_recursive_gap_radar",
+    "umya_test_files_gap_radar",
+    "umya_test_files_quick_plus_structural_mutation_coverage",
+    "powerpivot_contoso_sidecar_coverage",
+    "powerpivot_contoso_sidecar_excel_expected_unsupported",
+    "slicer_shared_two_pivots_sidecar_coverage",
+    "slicer_shared_two_pivots_sidecar_interactive_evidence",
+    "external_link_retarget_excel_app_open",
+    "public_powerbi_expanded_mutations",
+    "synthgl_recursive_mutation_coverage",
+    "synthgl_recursive_excel_render_noop_byte_identical",
+    "rename_sheet_defined_name_ref_audit_report",
+)
+
 OPEN_REQUIREMENTS = (
     {
         "id": "broader_real_world_corpus_diversity",
@@ -60,6 +82,10 @@ OPEN_REQUIREMENTS = (
 def audit_completion_claim(bundle_path: Path) -> dict:
     bundle_audit = audit_ooxml_evidence_bundle.audit_bundle(bundle_path)
     bundle_ready = bool(bundle_audit["ready"])
+    report_names = {str(report["name"]) for report in bundle_audit["reports"]}
+    missing_report_names = sorted(set(REQUIRED_CURRENT_EVIDENCE_REPORTS) - report_names)
+    required_reports_present = not missing_report_names
+    current_supported_claim_ready = bundle_ready and required_reports_present
     criteria = [
         {
             "id": "current_evidence_bundle_ready",
@@ -70,6 +96,22 @@ def audit_completion_claim(bundle_path: Path) -> dict:
                 "report_count": bundle_audit["report_count"],
                 "producer_count": bundle_audit["producer_count"],
                 "issue_count": bundle_audit["issue_count"],
+            },
+        },
+        {
+            "id": "current_evidence_required_reports_present",
+            "status": "satisfied" if required_reports_present else "missing",
+            "reason": (
+                "The current supported claim requires the named coverage, render, "
+                "app-open, interactive, corpus, gap-radar, sidecar, and broader "
+                "corpus evidence reports pinned in the bundle."
+            ),
+            "evidence": {
+                "required_report_count": len(REQUIRED_CURRENT_EVIDENCE_REPORTS),
+                "present_report_count": len(
+                    set(REQUIRED_CURRENT_EVIDENCE_REPORTS) & report_names
+                ),
+                "missing_reports": missing_report_names,
             },
         },
         *OPEN_REQUIREMENTS,
@@ -84,7 +126,7 @@ def audit_completion_claim(bundle_path: Path) -> dict:
         "exhaustive_claim": EXHAUSTIVE_CLAIM,
         "exhaustive_claim_ready": False,
         "current_supported_claim": CURRENT_SUPPORTED_CLAIM,
-        "current_supported_claim_ready": bundle_ready,
+        "current_supported_claim_ready": current_supported_claim_ready,
         "criteria": criteria,
         "missing_requirement_count": len(missing),
         "missing_requirements": missing,

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -24,7 +24,7 @@ completion = _load_completion_module()
 def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
     tmp_path: Path,
 ) -> None:
-    manifest = _write_bundle_manifest(tmp_path, ready=True)
+    manifest = _write_bundle_manifest(tmp_path, ready=True, include_required_reports=True)
 
     report = completion.audit_completion_claim(manifest)
 
@@ -43,16 +43,45 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
     }
 
 
-def test_completion_claim_audit_blocks_current_claim_when_bundle_is_stale(
+def test_completion_claim_audit_requires_named_current_evidence_reports(
     tmp_path: Path,
 ) -> None:
-    manifest = _write_bundle_manifest(tmp_path, ready=False)
+    manifest = _write_bundle_manifest(tmp_path, ready=True, include_required_reports=False)
 
     report = completion.audit_completion_claim(manifest)
 
     assert report["current_supported_claim_ready"] is False
     assert report["exhaustive_claim_ready"] is False
-    assert report["bundle_audit"]["issue_count"] == 1
+    assert report["bundle_audit"]["ready"] is True
+    required_reports = next(
+        criterion
+        for criterion in report["criteria"]
+        if criterion["id"] == "current_evidence_required_reports_present"
+    )
+    assert required_reports["status"] == "missing"
+    assert "combined_all_evidence_gate" in required_reports["evidence"]["missing_reports"]
+    assert report["missing_requirement_count"] == 5
+
+
+def test_completion_claim_audit_blocks_current_claim_when_bundle_is_stale(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_bundle_manifest(tmp_path, ready=False, include_required_reports=True)
+
+    report = completion.audit_completion_claim(manifest)
+
+    assert report["current_supported_claim_ready"] is False
+    assert report["exhaustive_claim_ready"] is False
+    assert report["bundle_audit"]["issue_count"] == (
+        len(completion.REQUIRED_CURRENT_EVIDENCE_REPORTS) + 1
+    )
+    required_reports = next(
+        criterion
+        for criterion in report["criteria"]
+        if criterion["id"] == "current_evidence_required_reports_present"
+    )
+    assert required_reports["status"] == "satisfied"
+    assert required_reports["evidence"]["missing_reports"] == []
     assert report["missing_requirements"][0]["id"] == "current_evidence_bundle_ready"
 
 
@@ -60,8 +89,12 @@ def test_completion_claim_strict_current_evidence_only_checks_bundle_freshness(
     tmp_path: Path,
     capsys,
 ) -> None:
-    ready_manifest = _write_bundle_manifest(tmp_path / "ready", ready=True)
-    stale_manifest = _write_bundle_manifest(tmp_path / "stale", ready=False)
+    ready_manifest = _write_bundle_manifest(
+        tmp_path / "ready", ready=True, include_required_reports=True
+    )
+    stale_manifest = _write_bundle_manifest(
+        tmp_path / "stale", ready=False, include_required_reports=True
+    )
 
     ready_code = completion.main([str(ready_manifest), "--strict-current-evidence"])
     ready_payload = json.loads(capsys.readouterr().out)
@@ -79,7 +112,7 @@ def test_completion_claim_strict_claim_fails_until_open_requirements_close(
     tmp_path: Path,
     capsys,
 ) -> None:
-    manifest = _write_bundle_manifest(tmp_path, ready=True)
+    manifest = _write_bundle_manifest(tmp_path, ready=True, include_required_reports=True)
 
     code = completion.main([str(manifest), "--strict-claim"])
 
@@ -90,23 +123,28 @@ def test_completion_claim_strict_claim_fails_until_open_requirements_close(
     assert payload["exhaustive_claim_ready"] is False
 
 
-def _write_bundle_manifest(tmp_path: Path, *, ready: bool) -> Path:
+def _write_bundle_manifest(
+    tmp_path: Path,
+    *,
+    ready: bool,
+    include_required_reports: bool,
+) -> Path:
     tmp_path.mkdir(parents=True, exist_ok=True)
-    report_path = tmp_path / "report.json"
-    report_path.write_text(json.dumps({"ready": ready}))
-    manifest = tmp_path / "bundle.json"
-    manifest.write_text(
-        json.dumps(
+    reports = []
+    names = ["current"]
+    if include_required_reports:
+        names.extend(completion.REQUIRED_CURRENT_EVIDENCE_REPORTS)
+    for index, name in enumerate(names):
+        report_path = tmp_path / f"report-{index}.json"
+        report_path.write_text(json.dumps({"ready": ready}))
+        reports.append(
             {
-                "reports": [
-                    {
-                        "name": "current",
-                        "path": str(report_path),
-                        "producer": "uv run --no-sync python scripts/example.py --strict",
-                        "expect": [{"path": "ready", "equals": True}],
-                    }
-                ]
+                "name": name,
+                "path": str(report_path),
+                "producer": "uv run --no-sync python scripts/example.py --strict",
+                "expect": [{"path": "ready", "equals": True}],
             }
         )
-    )
+    manifest = tmp_path / "bundle.json"
+    manifest.write_text(json.dumps({"reports": reports}))
     return manifest


### PR DESCRIPTION
## Summary
- require the completion-claim guard to see the named current evidence report classes before marking the scoped current claim ready
- expose missing required report names in the completion audit output
- update tests so a toy one-report bundle no longer supports the current claim

## Verification
- uv run --with pytest --with openpyxl --with-editable . python -m pytest tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q
- uv run --no-sync ruff check scripts/audit_ooxml_completion_claim.py tests/test_ooxml_completion_claim.py
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-claim-required-gates.json
- git diff --check