### PR TITLE
Clamp DrawingML anchors on structural deletes

### DIFF
--- a/crates/wolfxl-structural/src/drawing_shift.rs
+++ b/crates/wolfxl-structural/src/drawing_shift.rs
@@ -54,13 +54,9 @@ pub fn shift_drawing_xml(xml: &[u8], plan: &ShiftPlan) -> Vec<u8> {
                         Err(_) => String::from_utf8_lossy(t.as_ref()).into_owned(),
                     };
                     if let Ok(n) = s.trim().parse::<i64>() {
-                        if let Some(new_n) = shift_zero_based_point(n, plan) {
-                            let text = new_n.to_string();
-                            let new_t = BytesText::new(&text);
-                            let _ = writer.write_event(Event::Text(new_t));
-                        } else {
-                            let _ = writer.write_event(Event::Text(t.to_owned()));
-                        }
+                        let text = shift_zero_based_point(n, plan).to_string();
+                        let new_t = BytesText::new(&text);
+                        let _ = writer.write_event(Event::Text(new_t));
                     } else {
                         let _ = writer.write_event(Event::Text(t.to_owned()));
                     }
@@ -80,22 +76,22 @@ pub fn shift_drawing_xml(xml: &[u8], plan: &ShiftPlan) -> Vec<u8> {
     writer.into_inner().into_inner()
 }
 
-fn shift_zero_based_point(zero_based: i64, plan: &ShiftPlan) -> Option<i64> {
+fn shift_zero_based_point(zero_based: i64, plan: &ShiftPlan) -> i64 {
     if plan.is_insert() {
         if zero_based + 1 >= plan.idx as i64 {
-            Some(zero_based + plan.n as i64)
+            zero_based + plan.n as i64
         } else {
-            Some(zero_based)
+            zero_based
         }
     } else {
         let delete_start = plan.idx as i64 - 1;
         let delete_end = delete_start + plan.abs_n() as i64;
         if zero_based >= delete_start && zero_based < delete_end {
-            None
+            delete_start
         } else if zero_based >= delete_end {
-            Some(zero_based + plan.n as i64)
+            zero_based + plan.n as i64
         } else {
-            Some(zero_based)
+            zero_based
         }
     }
 }
@@ -121,5 +117,23 @@ mod tests {
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("<d:col>0</d:col>"), "{s}");
         assert!(s.contains("<d:col>5</d:col>"), "{s}");
+    }
+
+    #[test]
+    fn deleted_row_anchor_markers_snap_to_delete_boundary() {
+        let xml = br#"<xdr:wsDr><xdr:twoCellAnchor><xdr:from><xdr:row>5</xdr:row></xdr:from><xdr:to><xdr:row>8</xdr:row></xdr:to></xdr:twoCellAnchor></xdr:wsDr>"#;
+        let out = shift_drawing_xml(xml, &ShiftPlan::delete(Axis::Row, 5, 3));
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("<xdr:row>4</xdr:row>"), "{s}");
+        assert!(s.contains("<xdr:row>5</xdr:row>"), "{s}");
+    }
+
+    #[test]
+    fn deleted_col_anchor_markers_snap_to_delete_boundary() {
+        let xml = br#"<xdr:wsDr><xdr:twoCellAnchor><xdr:from><xdr:col>5</xdr:col></xdr:from><xdr:to><xdr:col>8</xdr:col></xdr:to></xdr:twoCellAnchor></xdr:wsDr>"#;
+        let out = shift_drawing_xml(xml, &ShiftPlan::delete(Axis::Col, 5, 3));
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("<xdr:col>4</xdr:col>"), "{s}");
+        assert!(s.contains("<xdr:col>5</xdr:col>"), "{s}");
     }
 }

--- a/tests/test_axis_shift_modify.py
+++ b/tests/test_axis_shift_modify.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import zipfile
 from pathlib import Path
+from xml.etree import ElementTree
 
 import openpyxl
 import pytest
@@ -76,6 +77,25 @@ def _make_hyperlink_fixture(path: Path) -> None:
 def _read_zip_text(path: Path, entry: str) -> str:
     with zipfile.ZipFile(path) as zf:
         return zf.read(entry).decode("utf-8")
+
+
+def _first_drawing_xml(path: Path) -> str:
+    with zipfile.ZipFile(path) as zf:
+        drawing_name = next(
+            name
+            for name in zf.namelist()
+            if name.startswith("xl/drawings/drawing") and name.endswith(".xml")
+        )
+        return zf.read(drawing_name).decode("utf-8")
+
+
+def _drawing_marker_values(path: Path, local_name: str) -> list[str]:
+    root = ElementTree.fromstring(_first_drawing_xml(path))
+    return [
+        str(node.text)
+        for node in root.iter()
+        if node.tag.rsplit("}", 1)[-1] == local_name and node.text is not None
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +264,51 @@ def test_hyperlink_anchor_shifts(tmp_path: Path) -> None:
     sheet_xml = _read_zip_text(dst, "xl/worksheets/sheet1.xml")
     # The hyperlink ref="B5" should have shifted to ref="B8".
     assert 'ref="B8"' in sheet_xml
+
+
+# ---------------------------------------------------------------------------
+# Tests — DrawingML anchors
+# ---------------------------------------------------------------------------
+
+
+def test_delete_rows_clamps_drawing_anchor_inside_deleted_band(tmp_path: Path) -> None:
+    src = tmp_path / "src.xlsx"
+    dst = tmp_path / "dst.xlsx"
+    from openpyxl.drawing.image import Image
+
+    image_path = Path(__file__).parent / "fixtures" / "images" / "tiny_red_dot.png"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws.add_image(Image(str(image_path)), "E6")
+    wb.save(src)
+
+    wb2 = wolfxl.load_workbook(src, modify=True)
+    ws2 = wb2.active
+    ws2.delete_rows(5, amount=3)
+    wb2.save(dst)
+
+    assert "4" in _drawing_marker_values(dst, "row")
+
+
+def test_delete_cols_clamps_drawing_anchor_inside_deleted_band(tmp_path: Path) -> None:
+    src = tmp_path / "src.xlsx"
+    dst = tmp_path / "dst.xlsx"
+    from openpyxl.drawing.image import Image
+
+    image_path = Path(__file__).parent / "fixtures" / "images" / "tiny_red_dot.png"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws.add_image(Image(str(image_path)), "F2")
+    wb.save(src)
+
+    wb2 = wolfxl.load_workbook(src, modify=True)
+    ws2 = wb2.active
+    ws2.delete_cols(5, amount=3)
+    wb2.save(dst)
+
+    assert "4" in _drawing_marker_values(dst, "col")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- clamp DrawingML anchor row/column references when structural deletes would otherwise remove or shift them below the deleted band
- preserve anchors by snapping deleted-band markers to the delete boundary and shifting markers after the deleted band normally
- add regression coverage for row and column deletes against real workbook drawing XML

## Verification
- uv run --no-sync python -m pytest tests/test_axis_shift_modify.py -q
- cargo test -q -p wolfxl-structural drawing_shift
- uv run --with ruff ruff check python/ tests/
- cargo check -q
- cargo test --workspace -q