### PR TITLE
Fix copy-sheet form-control render equivalence

### DIFF
--- a/crates/wolfxl-rels/src/part_id_allocator.rs
+++ b/crates/wolfxl-rels/src/part_id_allocator.rs
@@ -78,6 +78,9 @@ pub struct PartIdAllocator {
     next_threaded_comments: u32,
     // Real Excel form-control property parts.
     next_ctrl_prop: u32,
+    // Real Excel form-control VML shape IDs. The first authored form-control
+    // shape is conventionally `_x0000_s1025`.
+    next_vml_shape_id: u32,
 }
 
 impl Default for PartIdAllocator {
@@ -107,6 +110,7 @@ impl PartIdAllocator {
             next_timeline_cache: 1,
             next_threaded_comments: 1,
             next_ctrl_prop: 1,
+            next_vml_shape_id: 1025,
         }
     }
 
@@ -338,6 +342,24 @@ impl PartIdAllocator {
         n
     }
 
+    /// Seed the form-control VML shape-ID counter from the maximum existing
+    /// shape ID in the workbook package. Excel starts copied control shapes in
+    /// the next 1024-ID block (1025 -> 2049), while subsequent in-flight copies
+    /// keep consuming from the same allocator so IDs stay workbook-unique.
+    pub fn observe_vml_shape_id_max(&mut self, max_shape_id: u32) {
+        let next = next_vml_shape_id_block_start(max_shape_id);
+        if next > self.next_vml_shape_id {
+            self.next_vml_shape_id = next;
+        }
+    }
+
+    /// Allocate a fresh workbook-unique VML shape ID for copied form controls.
+    pub fn alloc_vml_shape_id(&mut self) -> u32 {
+        let n = self.next_vml_shape_id;
+        self.next_vml_shape_id = self.next_vml_shape_id.saturating_add(1);
+        n
+    }
+
     /// Peek at each counter without consuming. Test-only.
     #[cfg(test)]
     fn peek(&self) -> [u32; 7] {
@@ -351,6 +373,16 @@ impl PartIdAllocator {
             self.next_image,
         ]
     }
+}
+
+fn next_vml_shape_id_block_start(max_shape_id: u32) -> u32 {
+    let block = max_shape_id
+        .saturating_sub(1)
+        .checked_div(1024)
+        .unwrap_or(0)
+        .saturating_add(1)
+        .max(1);
+    block.saturating_mul(1024).saturating_add(1)
 }
 
 enum Counter {
@@ -438,6 +470,25 @@ mod tests {
         let mut a = PartIdAllocator::from_zip_parts(parts.iter().copied());
         assert_eq!(a.alloc_ctrl_prop(), 5);
         assert_eq!(a.alloc_ctrl_prop(), 6);
+    }
+
+    #[test]
+    fn vml_shape_id_counter_starts_at_next_excel_block() {
+        let mut a = PartIdAllocator::new();
+        a.observe_vml_shape_id_max(1025);
+        assert_eq!(a.alloc_vml_shape_id(), 2049);
+        assert_eq!(a.alloc_vml_shape_id(), 2050);
+        a.observe_vml_shape_id_max(1025);
+        assert_eq!(a.alloc_vml_shape_id(), 2051);
+    }
+
+    #[test]
+    fn vml_shape_id_observe_never_moves_backwards() {
+        let mut a = PartIdAllocator::new();
+        a.observe_vml_shape_id_max(2049);
+        assert_eq!(a.alloc_vml_shape_id(), 3073);
+        a.observe_vml_shape_id_max(1025);
+        assert_eq!(a.alloc_vml_shape_id(), 3074);
     }
 
     #[test]

--- a/crates/wolfxl-rels/src/part_id_allocator.rs
+++ b/crates/wolfxl-rels/src/part_id_allocator.rs
@@ -34,6 +34,7 @@
 //! | `xl/charts/chart<N>.xml`             | `next_chart`    |
 //! | `xl/charts/style<N>.xml`             | `next_chart_style` |
 //! | `xl/charts/colors<N>.xml`            | `next_chart_color` |
+//! | `xl/ctrlProps/ctrlProp<N>.xml`       | `next_ctrl_prop` |
 //!
 //! Any path with a non-numeric or missing suffix (e.g. `xl/tables/foo.xml`)
 //! is skipped — it does not contribute to any counter and does not panic.
@@ -75,6 +76,8 @@ pub struct PartIdAllocator {
     next_timeline_cache: u32,
     // Sprint Σ G08 (RFC-068 §5) — threaded-comment counter.
     next_threaded_comments: u32,
+    // Real Excel form-control property parts.
+    next_ctrl_prop: u32,
 }
 
 impl Default for PartIdAllocator {
@@ -103,6 +106,7 @@ impl PartIdAllocator {
             next_timeline: 1,
             next_timeline_cache: 1,
             next_threaded_comments: 1,
+            next_ctrl_prop: 1,
         }
     }
 
@@ -161,6 +165,8 @@ impl PartIdAllocator {
             self.bump(Counter::TimelineCache, n);
         } else if let Some(n) = parse_n(path, "xl/threadedComments/threadedComments", ".xml") {
             self.bump(Counter::ThreadedComments, n);
+        } else if let Some(n) = parse_n(path, "xl/ctrlProps/ctrlProp", ".xml") {
+            self.bump(Counter::CtrlProp, n);
         } else if path.starts_with("xl/media/image") {
             // Images use heterogeneous extensions (png/jpeg/gif/...) so a
             // generic strip+parse covers all of them.
@@ -191,6 +197,7 @@ impl PartIdAllocator {
             Counter::Timeline => &mut self.next_timeline,
             Counter::TimelineCache => &mut self.next_timeline_cache,
             Counter::ThreadedComments => &mut self.next_threaded_comments,
+            Counter::CtrlProp => &mut self.next_ctrl_prop,
         };
         if n + 1 > *slot {
             *slot = n + 1;
@@ -324,6 +331,13 @@ impl PartIdAllocator {
         n
     }
 
+    /// Allocate a fresh `ctrlPropN` suffix; returns `N` (>=1).
+    pub fn alloc_ctrl_prop(&mut self) -> u32 {
+        let n = self.next_ctrl_prop;
+        self.next_ctrl_prop += 1;
+        n
+    }
+
     /// Peek at each counter without consuming. Test-only.
     #[cfg(test)]
     fn peek(&self) -> [u32; 7] {
@@ -356,6 +370,7 @@ enum Counter {
     PivotTable,
     PivotCache,
     ThreadedComments,
+    CtrlProp,
 }
 
 // ---------------------------------------------------------------------------
@@ -375,6 +390,7 @@ mod tests {
         assert_eq!(a.alloc_drawing(), 1);
         assert_eq!(a.alloc_sheet(), 1);
         assert_eq!(a.alloc_chart(), 1);
+        assert_eq!(a.alloc_ctrl_prop(), 1);
     }
 
     #[test]
@@ -413,6 +429,15 @@ mod tests {
         assert_eq!(a.alloc_drawing(), 1);
         assert_eq!(a.alloc_sheet(), 1);
         assert_eq!(a.alloc_chart(), 1);
+        assert_eq!(a.alloc_ctrl_prop(), 1);
+    }
+
+    #[test]
+    fn from_zip_parts_seeds_ctrl_prop_counter() {
+        let parts = ["xl/ctrlProps/ctrlProp1.xml", "xl/ctrlProps/ctrlProp4.xml"];
+        let mut a = PartIdAllocator::from_zip_parts(parts.iter().copied());
+        assert_eq!(a.alloc_ctrl_prop(), 5);
+        assert_eq!(a.alloc_ctrl_prop(), 6);
     }
 
     #[test]

--- a/crates/wolfxl-structural/src/sheet_copy.rs
+++ b/crates/wolfxl-structural/src/sheet_copy.rs
@@ -837,11 +837,13 @@ pub fn plan_sheet_copy(inputs: SheetCopyInputs<'_>) -> Result<SheetCopyMutations
     }
     if !control_shape_id_remap.is_empty() {
         for (path, bytes) in &mut new_ancillary_parts {
-            if (path.starts_with("xl/drawings/drawing") && path.ends_with(".xml"))
-                || (path.starts_with("xl/drawings/vmlDrawing") && path.ends_with(".vml"))
-            {
+            if path.starts_with("xl/drawings/drawing") && path.ends_with(".xml") {
                 *bytes = rewrite_control_shape_ids(bytes, &control_shape_id_remap);
-                if path.starts_with("xl/drawings/vmlDrawing") && path.ends_with(".vml") {
+            } else if path.starts_with("xl/drawings/vmlDrawing") && path.ends_with(".vml") {
+                let control_ids = vml_control_shape_ids(bytes, &control_shape_id_remap);
+                if !control_ids.is_empty() {
+                    *bytes =
+                        rewrite_vml_control_shape_ids(bytes, &control_shape_id_remap, &control_ids);
                     *bytes = rewrite_vml_control_idmap_data(bytes, &control_shape_id_remap);
                 }
             }
@@ -1730,6 +1732,107 @@ fn rewrite_control_shape_ids(xml: &[u8], id_remap: &HashMap<String, String>) -> 
     attr_maps.insert("id".to_string(), shape_ref_remap.clone());
     attr_maps.insert("spid".to_string(), shape_ref_remap);
     rewrite_attributes_by_local_name(xml, &attr_maps)
+}
+
+fn rewrite_vml_control_shape_ids(
+    xml: &[u8],
+    id_remap: &HashMap<String, String>,
+    control_ids: &HashSet<String>,
+) -> Vec<u8> {
+    if control_ids.is_empty() {
+        return xml.to_vec();
+    }
+    let vml_id_remap: HashMap<String, String> = id_remap
+        .iter()
+        .map(|(old_id, new_id)| (format!("_x0000_s{old_id}"), format!("_x0000_s{new_id}")))
+        .filter(|(old_id, _)| control_ids.contains(old_id))
+        .collect();
+    if vml_id_remap.is_empty() {
+        return xml.to_vec();
+    }
+    let mut attr_maps = HashMap::new();
+    attr_maps.insert("id".to_string(), vml_id_remap);
+    let mut reader = XmlReader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut writer = XmlWriter::new(Vec::with_capacity(xml.len()));
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == b"shape" => {
+                let Ok(new_e) = rewrite_element_attrs_by_local_name(&e, &attr_maps) else {
+                    return xml.to_vec();
+                };
+                if writer.write_event(Event::Start(new_e)).is_err() {
+                    return xml.to_vec();
+                }
+            }
+            Ok(Event::Empty(e)) if e.local_name().as_ref() == b"shape" => {
+                let Ok(new_e) = rewrite_element_attrs_by_local_name(&e, &attr_maps) else {
+                    return xml.to_vec();
+                };
+                if writer.write_event(Event::Empty(new_e)).is_err() {
+                    return xml.to_vec();
+                }
+            }
+            Ok(Event::Eof) => break,
+            Ok(other) => {
+                if writer.write_event(other).is_err() {
+                    return xml.to_vec();
+                }
+            }
+            Err(_) => return xml.to_vec(),
+        }
+        buf.clear();
+    }
+    writer.into_inner()
+}
+
+fn vml_control_shape_ids(xml: &[u8], id_remap: &HashMap<String, String>) -> HashSet<String> {
+    let candidate_ids: HashSet<String> = id_remap
+        .keys()
+        .map(|old_id| format!("_x0000_s{old_id}"))
+        .collect();
+    let mut reader = XmlReader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut buf = Vec::new();
+    let mut shape_stack: Vec<Option<String>> = Vec::new();
+    let mut out = HashSet::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == b"shape" => {
+                let candidate = attr_value(&e, b"id").filter(|id| candidate_ids.contains(id));
+                shape_stack.push(candidate);
+            }
+            Ok(Event::Empty(e)) if e.local_name().as_ref() == b"ClientData" => {
+                if let Some(Some(shape_id)) = shape_stack.last() {
+                    if is_vml_control_client_data(&e) {
+                        out.insert(shape_id.clone());
+                    }
+                }
+            }
+            Ok(Event::Start(e)) if e.local_name().as_ref() == b"ClientData" => {
+                if let Some(Some(shape_id)) = shape_stack.last() {
+                    if is_vml_control_client_data(&e) {
+                        out.insert(shape_id.clone());
+                    }
+                }
+            }
+            Ok(Event::End(e)) if e.local_name().as_ref() == b"shape" => {
+                shape_stack.pop();
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    out
+}
+
+fn is_vml_control_client_data(e: &BytesStart<'_>) -> bool {
+    attr_value(e, b"ObjectType")
+        .map(|object_type| object_type != "Note")
+        .unwrap_or(false)
 }
 
 fn rewrite_vml_control_idmap_data(xml: &[u8], id_remap: &HashMap<String, String>) -> Vec<u8> {
@@ -2969,7 +3072,7 @@ mod tests {
         );
         zip_parts.insert(
             "xl/drawings/vmlDrawing1.vml".into(),
-            br#"<xml><o:shapelayout xmlns:o="urn:schemas-microsoft-com:office:office"><o:idmap data="1"/></o:shapelayout><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_x0000_s1025"/></xml>"#
+            br#"<xml><o:shapelayout xmlns:o="urn:schemas-microsoft-com:office:office"><o:idmap data="1"/></o:shapelayout><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_x0000_s1025"><x:ClientData xmlns:x="urn:schemas-microsoft-com:office:excel" ObjectType="List"/></v:shape></xml>"#
                 .to_vec(),
         );
         zip_parts.insert(
@@ -3057,6 +3160,35 @@ mod tests {
             .expect("cloned vml");
         assert!(cloned_vml.contains(r#"id="_x0000_s2049""#), "{cloned_vml}");
         assert!(cloned_vml.contains(r#"data="2""#), "{cloned_vml}");
+    }
+
+    #[test]
+    fn vml_control_shape_rewrite_ignores_comment_notes() {
+        let mut remap = HashMap::new();
+        remap.insert("1025".to_string(), "2049".to_string());
+        let comment_vml = br#"<xml><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_x0000_s1025"><x:ClientData xmlns:x="urn:schemas-microsoft-com:office:excel" ObjectType="Note"/></v:shape></xml>"#;
+        let control_vml = br#"<xml><o:shapelayout xmlns:o="urn:schemas-microsoft-com:office:office"><o:idmap data="1"/></o:shapelayout><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_x0000_s1025"><x:ClientData xmlns:x="urn:schemas-microsoft-com:office:excel" ObjectType="List"/></v:shape></xml>"#;
+
+        let comment_ids = vml_control_shape_ids(comment_vml, &remap);
+        assert!(comment_ids.is_empty());
+        let comment_out = rewrite_vml_control_shape_ids(comment_vml, &remap, &comment_ids);
+        let comment_out = std::str::from_utf8(&comment_out).unwrap();
+        assert!(
+            comment_out.contains(r#"id="_x0000_s1025""#),
+            "{comment_out}"
+        );
+        assert!(!comment_out.contains("_x0000_s2049"), "{comment_out}");
+
+        let control_ids = vml_control_shape_ids(control_vml, &remap);
+        assert!(control_ids.contains("_x0000_s1025"));
+        let control_out = rewrite_vml_control_shape_ids(control_vml, &remap, &control_ids);
+        let control_out = rewrite_vml_control_idmap_data(&control_out, &remap);
+        let control_out = std::str::from_utf8(&control_out).unwrap();
+        assert!(
+            control_out.contains(r#"id="_x0000_s2049""#),
+            "{control_out}"
+        );
+        assert!(control_out.contains(r#"data="2""#), "{control_out}");
     }
 
     #[test]

--- a/crates/wolfxl-structural/src/sheet_copy.rs
+++ b/crates/wolfxl-structural/src/sheet_copy.rs
@@ -213,6 +213,7 @@ const CT_DRAWING: &str = "application/vnd.openxmlformats-officedocument.drawing+
 const CT_CHART: &str = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml";
 const CT_CHART_STYLE: &str = "application/vnd.ms-office.chartstyle+xml";
 const CT_CHART_COLOR_STYLE: &str = "application/vnd.ms-office.chartcolorstyle+xml";
+const CT_CTRL_PROP: &str = "application/vnd.ms-excel.controlproperties+xml";
 const CT_TIMELINE: &str = "application/vnd.ms-excel.timeline+xml";
 const CT_TIMELINE_CACHE: &str = "application/vnd.ms-excel.timelineCache+xml";
 const RT_TIMELINE: &str = "http://schemas.microsoft.com/office/2011/relationships/timeline";
@@ -295,6 +296,15 @@ pub fn plan_sheet_copy(inputs: SheetCopyInputs<'_>) -> Result<SheetCopyMutations
     let mut taken_timeline_names = timeline_names_from_parts(zip_parts);
     let mut timeline_cache_name_remap: HashMap<String, String> = HashMap::new();
     let mut timeline_name_remap: HashMap<String, String> = HashMap::new();
+    let mut next_shape_id = next_vml_shape_id_block_start(max_shape_id_from_parts(zip_parts));
+    let mut control_shape_id_remap: HashMap<String, String> = HashMap::new();
+    for old_id in control_shape_ids_from_sheet(src_sheet_xml) {
+        control_shape_id_remap.entry(old_id).or_insert_with(|| {
+            let new_id = next_shape_id.to_string();
+            next_shape_id = next_shape_id.saturating_add(1);
+            new_id
+        });
+    }
 
     // For tracking the "set already used in this session" to dedup tables
     // when one copy clones two tables with the same base name.
@@ -404,6 +414,37 @@ pub fn plan_sheet_copy(inputs: SheetCopyInputs<'_>) -> Result<SheetCopyMutations
                         bytes: src_bytes,
                         new_part_path,
                         content_type: None,
+                        new_target,
+                    },
+                    &mut outputs,
+                );
+            }
+            // ------ Form-control property parts ------
+            //
+            // A sheet control's DrawingML/VML shape is sheet-local, and the
+            // matching ctrlProp part must be sheet-local too. Sharing the
+            // source `ctrlPropN.xml` across the source and cloned sheet opens
+            // in Excel, but real Excel renders some copied controls with
+            // different geometry.
+            t if t == rt::CTRL_PROP => {
+                let resolved =
+                    resolve_relative(parent_dir(&inputs.src_sheet_path), &source_rel.target);
+                let new_n = inputs.allocator.alloc_ctrl_prop();
+                let new_part_path = format!("xl/ctrlProps/ctrlProp{new_n}.xml");
+                let src_bytes = zip_parts.get(&resolved).cloned().unwrap_or_default();
+                let new_target = format!("../ctrlProps/ctrlProp{new_n}.xml");
+                let mut outputs = SheetRelCloneOutputs {
+                    dest_rels: &mut dest_rels,
+                    rid_remap: &mut rid_remap,
+                    new_ancillary_parts: &mut new_ancillary_parts,
+                    content_type_overrides_to_add: &mut content_type_overrides_to_add,
+                };
+                add_internal_part_clone(
+                    source_rel,
+                    InternalPartClone {
+                        bytes: src_bytes,
+                        new_part_path,
+                        content_type: Some(CT_CTRL_PROP),
                         new_target,
                     },
                     &mut outputs,
@@ -761,6 +802,7 @@ pub fn plan_sheet_copy(inputs: SheetCopyInputs<'_>) -> Result<SheetCopyMutations
 
     // ---- Apply the rId remap to the cloned sheet XML in one pass ----------
     let new_sheet_xml = rewrite_rids(src_sheet_xml, &rid_remap)?;
+    let new_sheet_xml = rewrite_control_shape_ids(&new_sheet_xml, &control_shape_id_remap);
 
     // ---- RFC-035 + RFC-057: translate any explicit-sheet refs inside
     // the cloned sheet's <f> formula text AND the <f t="array" ref="..."/>
@@ -790,6 +832,18 @@ pub fn plan_sheet_copy(inputs: SheetCopyInputs<'_>) -> Result<SheetCopyMutations
         for (path, bytes) in &mut new_ancillary_parts {
             if path.starts_with("xl/drawings/drawing") && path.ends_with(".xml") {
                 *bytes = rewrite_drawing_object_names(bytes, &timeline_name_remap);
+            }
+        }
+    }
+    if !control_shape_id_remap.is_empty() {
+        for (path, bytes) in &mut new_ancillary_parts {
+            if (path.starts_with("xl/drawings/drawing") && path.ends_with(".xml"))
+                || (path.starts_with("xl/drawings/vmlDrawing") && path.ends_with(".vml"))
+            {
+                *bytes = rewrite_control_shape_ids(bytes, &control_shape_id_remap);
+                if path.starts_with("xl/drawings/vmlDrawing") && path.ends_with(".vml") {
+                    *bytes = rewrite_vml_control_idmap_data(bytes, &control_shape_id_remap);
+                }
             }
         }
     }
@@ -1662,6 +1716,157 @@ fn rewrite_drawing_object_names(xml: &[u8], name_remap: &HashMap<String, String>
     rewrite_attributes_by_local_name(xml, &attr_maps)
 }
 
+fn rewrite_control_shape_ids(xml: &[u8], id_remap: &HashMap<String, String>) -> Vec<u8> {
+    if id_remap.is_empty() {
+        return xml.to_vec();
+    }
+    let mut shape_ref_remap = HashMap::new();
+    for (old_id, new_id) in id_remap {
+        shape_ref_remap.insert(old_id.clone(), new_id.clone());
+        shape_ref_remap.insert(format!("_x0000_s{old_id}"), format!("_x0000_s{new_id}"));
+    }
+    let mut attr_maps = HashMap::new();
+    attr_maps.insert("shapeId".to_string(), id_remap.clone());
+    attr_maps.insert("id".to_string(), shape_ref_remap.clone());
+    attr_maps.insert("spid".to_string(), shape_ref_remap);
+    rewrite_attributes_by_local_name(xml, &attr_maps)
+}
+
+fn rewrite_vml_control_idmap_data(xml: &[u8], id_remap: &HashMap<String, String>) -> Vec<u8> {
+    let Some(idmap_data) = id_remap
+        .values()
+        .filter_map(|value| value.parse::<u32>().ok())
+        .min()
+        .map(vml_shape_id_block_data)
+    else {
+        return xml.to_vec();
+    };
+    let idmap_data = idmap_data.to_string();
+    let mut reader = XmlReader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut writer = XmlWriter::new(Vec::with_capacity(xml.len()));
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == b"idmap" => {
+                let Ok(new_e) = rewrite_element_attr_value_by_local_name(&e, "data", &idmap_data)
+                else {
+                    return xml.to_vec();
+                };
+                if writer.write_event(Event::Start(new_e)).is_err() {
+                    return xml.to_vec();
+                }
+            }
+            Ok(Event::Empty(e)) if e.local_name().as_ref() == b"idmap" => {
+                let Ok(new_e) = rewrite_element_attr_value_by_local_name(&e, "data", &idmap_data)
+                else {
+                    return xml.to_vec();
+                };
+                if writer.write_event(Event::Empty(new_e)).is_err() {
+                    return xml.to_vec();
+                }
+            }
+            Ok(Event::Eof) => break,
+            Ok(other) => {
+                if writer.write_event(other).is_err() {
+                    return xml.to_vec();
+                }
+            }
+            Err(_) => return xml.to_vec(),
+        }
+        buf.clear();
+    }
+    writer.into_inner()
+}
+
+fn control_shape_ids_from_sheet(sheet_xml: &[u8]) -> Vec<String> {
+    let mut reader = XmlReader::from_reader(sheet_xml);
+    reader.config_mut().trim_text(false);
+    let mut buf = Vec::new();
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) | Ok(Event::Empty(e)) if e.local_name().as_ref() == b"control" => {
+                if let Some(value) = attr_value(&e, b"shapeId") {
+                    if value.chars().all(|c| c.is_ascii_digit()) {
+                        out.push(value);
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    out
+}
+
+fn max_shape_id_from_parts(zip_parts: &HashMap<String, Vec<u8>>) -> u32 {
+    zip_parts
+        .values()
+        .flat_map(|bytes| shape_ids_from_xml(bytes))
+        .max()
+        .unwrap_or(0)
+}
+
+fn next_vml_shape_id_block_start(max_shape_id: u32) -> u32 {
+    let block = vml_shape_id_block_data(max_shape_id)
+        .saturating_add(1)
+        .max(1);
+    block.saturating_mul(1024).saturating_add(1)
+}
+
+fn vml_shape_id_block_data(shape_id: u32) -> u32 {
+    shape_id.saturating_sub(1) / 1024
+}
+
+fn shape_ids_from_xml(xml: &[u8]) -> Vec<u32> {
+    let mut reader = XmlReader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut buf = Vec::new();
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) | Ok(Event::Empty(e)) => {
+                for attr in e.attributes().with_checks(false).flatten() {
+                    let key = attr.key.as_ref().to_vec();
+                    let local_key = key.rsplit(|b| *b == b':').next().unwrap_or(key.as_slice());
+                    let value = attr
+                        .unescape_value()
+                        .map(|v| v.into_owned())
+                        .unwrap_or_else(|_| {
+                            String::from_utf8_lossy(attr.value.as_ref()).into_owned()
+                        });
+                    match local_key {
+                        b"shapeId" => {
+                            if let Ok(id) = value.parse::<u32>() {
+                                out.push(id);
+                            }
+                        }
+                        b"id" | b"spid" => {
+                            if let Some(id) = value
+                                .strip_prefix("_x0000_s")
+                                .and_then(|suffix| suffix.parse::<u32>().ok())
+                            {
+                                out.push(id);
+                            } else if let Ok(id) = value.parse::<u32>() {
+                                out.push(id);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    out
+}
+
 fn rewrite_table_formula_refs(xml: &[u8], table_name_remap: &HashMap<String, String>) -> Vec<u8> {
     if table_name_remap.is_empty() {
         return xml.to_vec();
@@ -1757,6 +1962,32 @@ fn rewrite_element_attrs_by_local_name(
             .cloned()
             .unwrap_or(value);
         push_attr_escaped(&mut new_e, &key, &new_value);
+    }
+    Ok(new_e)
+}
+
+fn rewrite_element_attr_value_by_local_name(
+    e: &BytesStart<'_>,
+    attr_name: &str,
+    attr_value: &str,
+) -> Result<BytesStart<'static>, SheetCopyError> {
+    let mut new_e = BytesStart::new(
+        std::str::from_utf8(e.name().as_ref())
+            .map_err(|er| SheetCopyError::Xml(format!("element name utf8: {er}")))?
+            .to_owned(),
+    );
+    for a in e.attributes().with_checks(false).flatten() {
+        let key = a.key.as_ref().to_vec();
+        let local_key = key.rsplit(|b| *b == b':').next().unwrap_or(key.as_slice());
+        if local_key == attr_name.as_bytes() {
+            push_attr_escaped(&mut new_e, &key, attr_value);
+        } else {
+            let value = a
+                .unescape_value()
+                .map(|v| v.into_owned())
+                .unwrap_or_else(|_| String::from_utf8_lossy(a.value.as_ref()).into_owned());
+            push_attr_escaped(&mut new_e, &key, &value);
+        }
     }
     Ok(new_e)
 }
@@ -2722,6 +2953,110 @@ mod tests {
             .collect();
         assert!(paths.contains(&"xl/comments2.xml"), "{paths:?}");
         assert!(paths.contains(&"xl/drawings/vmlDrawing2.vml"), "{paths:?}");
+    }
+
+    #[test]
+    fn clone_with_form_control_properties_allocates_fresh_ctrl_prop() {
+        let mut alloc = PartIdAllocator::new();
+        let mut zip_parts: HashMap<String, Vec<u8>> = HashMap::new();
+        zip_parts.insert(
+            "xl/worksheets/sheet1.xml".into(),
+            br#"<?xml version="1.0"?><worksheet xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><controls><control shapeId="1025" r:id="rId1"/></controls><legacyDrawing r:id="rId2"/><drawing r:id="rId3"/></worksheet>"#.to_vec(),
+        );
+        zip_parts.insert(
+            "xl/ctrlProps/ctrlProp1.xml".into(),
+            b"<formControlPr/>".to_vec(),
+        );
+        zip_parts.insert(
+            "xl/drawings/vmlDrawing1.vml".into(),
+            br#"<xml><o:shapelayout xmlns:o="urn:schemas-microsoft-com:office:office"><o:idmap data="1"/></o:shapelayout><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_x0000_s1025"/></xml>"#
+                .to_vec(),
+        );
+        zip_parts.insert(
+            "xl/drawings/drawing1.xml".into(),
+            br#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main"><xdr:cNvPr id="1025"><a14:compatExt spid="_x0000_s1025"/></xdr:cNvPr></xdr:wsDr>"#.to_vec(),
+        );
+        let workbook_bytes = one_sheet_workbook(&[], &[]);
+        let existing_table_names: HashSet<String> = HashSet::new();
+        let source_rels = rels_with(&[
+            (
+                rt::CTRL_PROP,
+                "../ctrlProps/ctrlProp1.xml",
+                TargetMode::Internal,
+            ),
+            (
+                rt::VML_DRAWING,
+                "../drawings/vmlDrawing1.vml",
+                TargetMode::Internal,
+            ),
+            (
+                rt::DRAWING,
+                "../drawings/drawing1.xml",
+                TargetMode::Internal,
+            ),
+        ]);
+        for p in zip_parts.keys() {
+            alloc.observe(p);
+        }
+
+        let mutations = plan_sheet_copy(SheetCopyInputs {
+            src_title: "Template".into(),
+            dst_title: "T2".into(),
+            src_sheet_path: "xl/worksheets/sheet1.xml".into(),
+            source_zip_parts: &zip_parts,
+            source_rels: &source_rels,
+            workbook_xml: &workbook_bytes,
+            allocator: &mut alloc,
+            existing_table_names: &existing_table_names,
+            deep_copy_images: false,
+        })
+        .expect("plan ok");
+
+        let paths: Vec<&str> = mutations
+            .new_ancillary_parts
+            .iter()
+            .map(|(p, _)| p.as_str())
+            .collect();
+        assert!(paths.contains(&"xl/ctrlProps/ctrlProp2.xml"), "{paths:?}");
+        assert!(mutations
+            .content_type_overrides_to_add
+            .contains(&("/xl/ctrlProps/ctrlProp2.xml".into(), CT_CTRL_PROP.into())));
+        let dest_rels = mutations
+            .new_ancillary_parts
+            .iter()
+            .find(|(p, _)| p == "xl/worksheets/_rels/sheet2.xml.rels")
+            .map(|(_, bytes)| std::str::from_utf8(bytes).unwrap().to_string())
+            .expect("dest rels emitted");
+        assert!(
+            dest_rels.contains("../ctrlProps/ctrlProp2.xml"),
+            "{dest_rels}"
+        );
+        assert!(
+            !dest_rels.contains("../ctrlProps/ctrlProp1.xml"),
+            "{dest_rels}"
+        );
+        let sheet = std::str::from_utf8(&mutations.new_sheet_xml).unwrap();
+        assert!(sheet.contains(r#"shapeId="2049""#), "{sheet}");
+        assert!(!sheet.contains(r#"shapeId="1025""#), "{sheet}");
+        let cloned_drawing = mutations
+            .new_ancillary_parts
+            .iter()
+            .find(|(p, _)| p == "xl/drawings/drawing2.xml")
+            .map(|(_, bytes)| std::str::from_utf8(bytes).unwrap().to_string())
+            .expect("cloned drawing");
+        assert!(cloned_drawing.contains(r#"id="2049""#), "{cloned_drawing}");
+        assert!(
+            cloned_drawing.contains(r#"spid="_x0000_s2049""#),
+            "{cloned_drawing}"
+        );
+        let cloned_vml = mutations
+            .new_ancillary_parts
+            .iter()
+            .find(|(p, _)| p == "xl/drawings/vmlDrawing2.vml")
+            .map(|(_, bytes)| std::str::from_utf8(bytes).unwrap().to_string())
+            .expect("cloned vml");
+        assert!(cloned_vml.contains(r#"id="_x0000_s2049""#), "{cloned_vml}");
+        assert!(cloned_vml.contains(r#"data="2""#), "{cloned_vml}");
     }
 
     #[test]

--- a/crates/wolfxl-structural/src/sheet_copy.rs
+++ b/crates/wolfxl-structural/src/sheet_copy.rs
@@ -296,14 +296,14 @@ pub fn plan_sheet_copy(inputs: SheetCopyInputs<'_>) -> Result<SheetCopyMutations
     let mut taken_timeline_names = timeline_names_from_parts(zip_parts);
     let mut timeline_cache_name_remap: HashMap<String, String> = HashMap::new();
     let mut timeline_name_remap: HashMap<String, String> = HashMap::new();
-    let mut next_shape_id = next_vml_shape_id_block_start(max_shape_id_from_parts(zip_parts));
+    inputs
+        .allocator
+        .observe_vml_shape_id_max(max_shape_id_from_parts(zip_parts));
     let mut control_shape_id_remap: HashMap<String, String> = HashMap::new();
     for old_id in control_shape_ids_from_sheet(src_sheet_xml) {
-        control_shape_id_remap.entry(old_id).or_insert_with(|| {
-            let new_id = next_shape_id.to_string();
-            next_shape_id = next_shape_id.saturating_add(1);
-            new_id
-        });
+        control_shape_id_remap
+            .entry(old_id)
+            .or_insert_with(|| inputs.allocator.alloc_vml_shape_id().to_string());
     }
 
     // For tracking the "set already used in this session" to dedup tables
@@ -1913,13 +1913,6 @@ fn max_shape_id_from_parts(zip_parts: &HashMap<String, Vec<u8>>) -> u32 {
         .unwrap_or(0)
 }
 
-fn next_vml_shape_id_block_start(max_shape_id: u32) -> u32 {
-    let block = vml_shape_id_block_data(max_shape_id)
-        .saturating_add(1)
-        .max(1);
-    block.saturating_mul(1024).saturating_add(1)
-}
-
 fn vml_shape_id_block_data(shape_id: u32) -> u32 {
     shape_id.saturating_sub(1) / 1024
 }
@@ -3160,6 +3153,25 @@ mod tests {
             .expect("cloned vml");
         assert!(cloned_vml.contains(r#"id="_x0000_s2049""#), "{cloned_vml}");
         assert!(cloned_vml.contains(r#"data="2""#), "{cloned_vml}");
+
+        let second = plan_sheet_copy(SheetCopyInputs {
+            src_title: "Template".into(),
+            dst_title: "T3".into(),
+            src_sheet_path: "xl/worksheets/sheet1.xml".into(),
+            source_zip_parts: &zip_parts,
+            source_rels: &source_rels,
+            workbook_xml: &workbook_bytes,
+            allocator: &mut alloc,
+            existing_table_names: &existing_table_names,
+            deep_copy_images: false,
+        })
+        .expect("second plan ok");
+        let second_sheet = std::str::from_utf8(&second.new_sheet_xml).unwrap();
+        assert!(second_sheet.contains(r#"shapeId="2050""#), "{second_sheet}");
+        assert!(
+            !second_sheet.contains(r#"shapeId="2049""#),
+            "{second_sheet}"
+        );
     }
 
     #[test]

--- a/scripts/audit_ooxml_copy_sheet_render_equivalence.py
+++ b/scripts/audit_ooxml_copy_sheet_render_equivalence.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Audit rendered equivalence for copy-first-sheet OOXML mutations.
+
+The intentional render smoke proves the copied workbook can be exported by
+Excel, but it does not prove the copied sheet still looks like the original
+sheet. This audit reuses the already-rasterized after-workbook pages and checks
+whether page 1 has an exact or near-exact later-page match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import zipfile
+from dataclasses import asdict, dataclass
+from xml.etree import ElementTree
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import run_ooxml_render_compare  # noqa: E402
+
+MUTATION = "copy_first_sheet"
+PASSING_RENDER_STATUSES = {"rendered", "sampled_rendered"}
+PAGE_RE = re.compile(r"^after-pages-(?P<page>\d+)(?:-\d+)?\.png$")
+
+
+@dataclass(frozen=True)
+class CopySheetEquivalenceResult:
+    fixture: str
+    status: str
+    source_page: int | None
+    matched_page: int | None
+    compared_pages: list[int]
+    normalized_rmse: float | None
+    sampled: bool
+    message: str
+
+
+def audit_copy_sheet_render_equivalence(
+    render_report_path: Path,
+    max_normalized_rmse: float = 0.001,
+    timeout: int = 30,
+) -> dict:
+    payload = json.loads(render_report_path.read_text())
+    compare_cmd = run_ooxml_render_compare._find_imagemagick_compare()
+    results: list[CopySheetEquivalenceResult] = []
+    for result in payload.get("results", []):
+        if result.get("mutation") != MUTATION:
+            continue
+        results.append(
+            _audit_result(
+                result,
+                compare_cmd=compare_cmd,
+                max_normalized_rmse=max_normalized_rmse,
+                timeout=timeout,
+            )
+        )
+
+    passed_count = sum(1 for result in results if result.status == "passed")
+    failure_count = sum(1 for result in results if result.status == "failed")
+    inconclusive_count = sum(1 for result in results if result.status == "inconclusive")
+    skipped_count = sum(1 for result in results if result.status == "skipped")
+    return {
+        "render_report": str(render_report_path),
+        "mutation": MUTATION,
+        "max_normalized_rmse_threshold": max_normalized_rmse,
+        "result_count": len(results),
+        "passed_count": passed_count,
+        "failure_count": failure_count,
+        "inconclusive_count": inconclusive_count,
+        "skipped_count": skipped_count,
+        "ready": passed_count > 0 and failure_count == 0,
+        "results": [asdict(result) for result in results],
+    }
+
+
+def _audit_result(
+    result: dict,
+    compare_cmd: tuple[str, ...] | None,
+    max_normalized_rmse: float,
+    timeout: int,
+) -> CopySheetEquivalenceResult:
+    fixture = str(result.get("fixture", ""))
+    status = str(result.get("status", ""))
+    if status not in PASSING_RENDER_STATUSES:
+        return CopySheetEquivalenceResult(
+            fixture=fixture,
+            status="skipped",
+            source_page=None,
+            matched_page=None,
+            compared_pages=[],
+            normalized_rmse=None,
+            sampled=False,
+            message=f"render result status is not passing: {status}",
+        )
+
+    after_pdf = result.get("after_pdf")
+    if not isinstance(after_pdf, str):
+        return _inconclusive(fixture, "render result has no after_pdf")
+    result_dir = Path(after_pdf).parent.parent
+    if _source_first_sheet_hidden(result_dir):
+        return _inconclusive(
+            fixture,
+            "source first sheet is hidden; no rendered source page to compare",
+        )
+    pages = _after_pages(result_dir)
+    if 1 not in pages:
+        return _inconclusive(fixture, "page 1 image is missing")
+    later_pages = [page for page in sorted(pages) if page > 1]
+    if not later_pages:
+        return _inconclusive(fixture, "no later rendered page to compare against page 1")
+
+    best_page: int | None = None
+    best_rmse: float | None = None
+    source = pages[1]
+    for page_number in later_pages:
+        rmse = _page_rmse(source, pages[page_number], compare_cmd, timeout)
+        if best_rmse is None or rmse < best_rmse:
+            best_rmse = rmse
+            best_page = page_number
+        if rmse <= max_normalized_rmse:
+            return CopySheetEquivalenceResult(
+                fixture=fixture,
+                status="passed",
+                source_page=1,
+                matched_page=page_number,
+                compared_pages=later_pages,
+                normalized_rmse=rmse,
+                sampled=_is_sampled(result),
+                message=(
+                    f"page 1 matched copied-sheet candidate page {page_number}: "
+                    f"normalized_rmse={rmse:.8f}"
+                ),
+            )
+
+    sampled = _is_sampled(result)
+    message = (
+        f"no sampled later page matched page 1; best_page={best_page} "
+        f"best_normalized_rmse={best_rmse:.8f}"
+        if best_rmse is not None
+        else "no comparable later page was available"
+    )
+    return CopySheetEquivalenceResult(
+        fixture=fixture,
+        status="inconclusive" if sampled else "failed",
+        source_page=1,
+        matched_page=None,
+        compared_pages=later_pages,
+        normalized_rmse=best_rmse,
+        sampled=sampled,
+        message=message,
+    )
+
+
+def _after_pages(result_dir: Path) -> dict[int, Path]:
+    pages: dict[int, Path] = {}
+    for path in result_dir.glob("after-pages-*.png"):
+        match = PAGE_RE.match(path.name)
+        if match is None:
+            continue
+        page = int(match.group("page"))
+        pages[page] = path
+    return pages
+
+
+def _page_rmse(
+    source: Path,
+    candidate: Path,
+    compare_cmd: tuple[str, ...] | None,
+    timeout: int,
+) -> float:
+    if _sha256(source) == _sha256(candidate):
+        return 0.0
+    if compare_cmd is None:
+        raise RuntimeError(
+            "ImageMagick compare is required when page PNGs are not byte-identical"
+        )
+    return run_ooxml_render_compare._normalized_rmse(
+        compare_cmd,
+        source,
+        candidate,
+        timeout,
+    )
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _is_sampled(result: dict) -> bool:
+    status = str(result.get("status", ""))
+    page_count = result.get("page_count")
+    compared_page_count = result.get("compared_page_count")
+    return status.startswith("sampled_") or (
+        isinstance(page_count, int)
+        and isinstance(compared_page_count, int)
+        and page_count > compared_page_count
+    )
+
+
+def _source_first_sheet_hidden(result_dir: Path) -> bool:
+    candidates = sorted(result_dir.glob("after-*.xlsx"))
+    if not candidates:
+        return False
+    try:
+        with zipfile.ZipFile(candidates[0]) as zf:
+            workbook_xml = zf.read("xl/workbook.xml")
+    except (KeyError, OSError, zipfile.BadZipFile):
+        return False
+    try:
+        root = ElementTree.fromstring(workbook_xml)
+    except ElementTree.ParseError:
+        return False
+    ns = {"x": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+    first_sheet = root.find("x:sheets/x:sheet", ns)
+    if first_sheet is None:
+        return False
+    return first_sheet.attrib.get("state") in {"hidden", "veryHidden"}
+
+
+def _inconclusive(fixture: str, message: str) -> CopySheetEquivalenceResult:
+    return CopySheetEquivalenceResult(
+        fixture=fixture,
+        status="inconclusive",
+        source_page=None,
+        matched_page=None,
+        compared_pages=[],
+        normalized_rmse=None,
+        sampled=False,
+        message=message,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("render_report", type=Path)
+    parser.add_argument("--max-normalized-rmse", type=float, default=0.001)
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when no duplicate render evidence is found or failures exist.",
+    )
+    args = parser.parse_args(argv)
+    report = audit_copy_sheet_render_equivalence(
+        args.render_report,
+        max_normalized_rmse=args.max_normalized_rmse,
+        timeout=args.timeout,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if args.strict and not report["ready"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_ooxml_copy_sheet_render_equivalence.py
+++ b/scripts/audit_ooxml_copy_sheet_render_equivalence.py
@@ -141,7 +141,8 @@ def _audit_result(
 
     sampled = _is_sampled(result)
     message = (
-        f"no sampled later page matched page 1; best_page={best_page} "
+        f"{'no sampled later page' if sampled else 'no later page'} matched page 1; "
+        f"best_page={best_page} "
         f"best_normalized_rmse={best_rmse:.8f}"
         if best_rmse is not None
         else "no comparable later page was available"

--- a/tests/test_copy_worksheet_control_props.py
+++ b/tests/test_copy_worksheet_control_props.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from wolfxl import load_workbook
+
+
+def test_copy_worksheet_clones_form_control_properties(tmp_path: Path) -> None:
+    src = Path("tests/fixtures/external_oracle/real-excel-control-props-basic.xlsx")
+    dst = tmp_path / "copied-control-props.xlsx"
+
+    wb = load_workbook(src, modify=True)
+    wb.copy_worksheet(wb.worksheets[0], name="Copied Control Props")
+    wb.save(dst)
+
+    with zipfile.ZipFile(dst) as zf:
+        names = set(zf.namelist())
+        assert "xl/ctrlProps/ctrlProp1.xml" in names
+        assert "xl/ctrlProps/ctrlProp2.xml" in names
+
+        sheet2_rels = zf.read("xl/worksheets/_rels/sheet2.xml.rels").decode()
+        assert "../ctrlProps/ctrlProp2.xml" in sheet2_rels
+        assert "../ctrlProps/ctrlProp1.xml" not in sheet2_rels
+
+        content_types = zf.read("[Content_Types].xml").decode()
+        assert 'PartName="/xl/ctrlProps/ctrlProp2.xml"' in content_types
+
+        sheet2 = zf.read("xl/worksheets/sheet2.xml").decode()
+        drawing2 = zf.read("xl/drawings/drawing2.xml").decode()
+        vml2 = zf.read("xl/drawings/vmlDrawing2.vml").decode()
+        assert 'shapeId="2049"' in sheet2
+        assert 'shapeId="1025"' not in sheet2
+        assert 'id="2049"' in drawing2
+        assert 'spid="_x0000_s2049"' in drawing2
+        assert 'data="2"' in vml2
+        assert 'id="_x0000_s2049"' in vml2

--- a/tests/test_ooxml_copy_sheet_render_equivalence.py
+++ b/tests/test_ooxml_copy_sheet_render_equivalence.py
@@ -72,8 +72,8 @@ def _write_fake_render_result(
 def test_copy_sheet_render_equivalence_accepts_duplicate_later_page(tmp_path: Path) -> None:
     report = _write_fake_render_result(tmp_path, fixture="book")
     work = tmp_path / "book" / "copy_first_sheet"
-    (work / "after-pages-1.png").write_bytes(BLACK_PNG)
-    (work / "after-pages-2.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-1-1.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-2-2.png").write_bytes(BLACK_PNG)
 
     result = audit.audit_copy_sheet_render_equivalence(report)
 
@@ -100,8 +100,8 @@ def test_copy_sheet_render_equivalence_fails_full_render_without_match(
     )
     report = _write_fake_render_result(tmp_path, fixture="book")
     work = tmp_path / "book" / "copy_first_sheet"
-    (work / "after-pages-1.png").write_bytes(BLACK_PNG)
-    (work / "after-pages-2.png").write_bytes(WHITE_PNG)
+    (work / "after-pages-1-1.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-2-2.png").write_bytes(WHITE_PNG)
 
     result = audit.audit_copy_sheet_render_equivalence(report)
 
@@ -160,8 +160,8 @@ def test_copy_sheet_render_equivalence_marks_hidden_source_inconclusive(
     )
     report = _write_fake_render_result(tmp_path, fixture="book")
     work = tmp_path / "book" / "copy_first_sheet"
-    (work / "after-pages-1.png").write_bytes(BLACK_PNG)
-    (work / "after-pages-2.png").write_bytes(WHITE_PNG)
+    (work / "after-pages-1-1.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-2-2.png").write_bytes(WHITE_PNG)
     with zipfile.ZipFile(work / "after-book.xlsx", "w") as zf:
         zf.writestr(
             "xl/workbook.xml",

--- a/tests/test_ooxml_copy_sheet_render_equivalence.py
+++ b/tests/test_ooxml_copy_sheet_render_equivalence.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import zipfile
+from base64 import b64decode
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_module() -> ModuleType:
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "audit_ooxml_copy_sheet_render_equivalence.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "audit_ooxml_copy_sheet_render_equivalence", script
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+audit = _load_module()
+
+BLACK_PNG = b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR4nGNgYGD4DwABBAEA"
+    "gh9eJgAAAABJRU5ErkJggg=="
+)
+WHITE_PNG = b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR4nGP4z8AAAAMBAQDJ/"
+    "pLvAAAAAElFTkSuQmCC"
+)
+
+
+def _write_fake_render_result(
+    tmp_path: Path,
+    *,
+    fixture: str,
+    status: str = "rendered",
+    page_count: int = 2,
+    compared_pages: list[int] | None = None,
+) -> Path:
+    work = tmp_path / fixture / "copy_first_sheet"
+    after_pdf_dir = work / "after-pdf"
+    after_pdf_dir.mkdir(parents=True)
+    after_pdf = after_pdf_dir / f"after-{fixture}.pdf"
+    after_pdf.write_bytes(b"%PDF-1.4\n")
+    payload = {
+        "results": [
+            {
+                "fixture": f"{fixture}.xlsx",
+                "mutation": "copy_first_sheet",
+                "status": status,
+                "after_pdf": str(after_pdf),
+                "page_count": page_count,
+                "compared_page_count": len(compared_pages or [1, 2]),
+                "compared_pages": compared_pages or [1, 2],
+            }
+        ]
+    }
+    report = tmp_path / "render-report.json"
+    report.write_text(json.dumps(payload))
+    return report
+
+
+def test_copy_sheet_render_equivalence_accepts_duplicate_later_page(tmp_path: Path) -> None:
+    report = _write_fake_render_result(tmp_path, fixture="book")
+    work = tmp_path / "book" / "copy_first_sheet"
+    (work / "after-pages-1.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-2.png").write_bytes(BLACK_PNG)
+
+    result = audit.audit_copy_sheet_render_equivalence(report)
+
+    assert result["ready"] is True
+    assert result["passed_count"] == 1
+    assert result["failure_count"] == 0
+    assert result["results"][0]["matched_page"] == 2
+    assert result["results"][0]["normalized_rmse"] == 0.0
+
+
+def test_copy_sheet_render_equivalence_fails_full_render_without_match(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        audit.run_ooxml_render_compare,
+        "_find_imagemagick_compare",
+        lambda: ("compare",),
+    )
+    monkeypatch.setattr(
+        audit.run_ooxml_render_compare,
+        "_normalized_rmse",
+        lambda *args, **kwargs: 1.0,
+    )
+    report = _write_fake_render_result(tmp_path, fixture="book")
+    work = tmp_path / "book" / "copy_first_sheet"
+    (work / "after-pages-1.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-2.png").write_bytes(WHITE_PNG)
+
+    result = audit.audit_copy_sheet_render_equivalence(report)
+
+    assert result["ready"] is False
+    assert result["failure_count"] == 1
+    assert result["results"][0]["status"] == "failed"
+
+
+def test_copy_sheet_render_equivalence_marks_sampled_without_match_inconclusive(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        audit.run_ooxml_render_compare,
+        "_find_imagemagick_compare",
+        lambda: ("compare",),
+    )
+    monkeypatch.setattr(
+        audit.run_ooxml_render_compare,
+        "_normalized_rmse",
+        lambda *args, **kwargs: 1.0,
+    )
+    report = _write_fake_render_result(
+        tmp_path,
+        fixture="book",
+        status="sampled_rendered",
+        page_count=5,
+        compared_pages=[1, 3, 5],
+    )
+    work = tmp_path / "book" / "copy_first_sheet"
+    (work / "after-pages-1-1.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-3-3.png").write_bytes(WHITE_PNG)
+    (work / "after-pages-5-5.png").write_bytes(WHITE_PNG)
+
+    result = audit.audit_copy_sheet_render_equivalence(report)
+
+    assert result["ready"] is False
+    assert result["failure_count"] == 0
+    assert result["inconclusive_count"] == 1
+    assert result["results"][0]["sampled"] is True
+
+
+def test_copy_sheet_render_equivalence_marks_hidden_source_inconclusive(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        audit.run_ooxml_render_compare,
+        "_find_imagemagick_compare",
+        lambda: ("compare",),
+    )
+    monkeypatch.setattr(
+        audit.run_ooxml_render_compare,
+        "_normalized_rmse",
+        lambda *args, **kwargs: 1.0,
+    )
+    report = _write_fake_render_result(tmp_path, fixture="book")
+    work = tmp_path / "book" / "copy_first_sheet"
+    (work / "after-pages-1.png").write_bytes(BLACK_PNG)
+    (work / "after-pages-2.png").write_bytes(WHITE_PNG)
+    with zipfile.ZipFile(work / "after-book.xlsx", "w") as zf:
+        zf.writestr(
+            "xl/workbook.xml",
+            (
+                '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+                'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+                '<sheets><sheet name="Hidden" sheetId="1" state="hidden" r:id="rId1"/>'
+                '<sheet name="Visible" sheetId="2" r:id="rId2"/></sheets></workbook>'
+            ),
+        )
+
+    result = audit.audit_copy_sheet_render_equivalence(report)
+
+    assert result["ready"] is False
+    assert result["failure_count"] == 0
+    assert result["inconclusive_count"] == 1
+    assert result["results"][0]["status"] == "inconclusive"
+    assert "source first sheet is hidden" in result["results"][0]["message"]
+
+
+def test_copy_sheet_render_equivalence_ignores_other_mutations(tmp_path: Path) -> None:
+    report = tmp_path / "render-report.json"
+    report.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "fixture": "book.xlsx",
+                        "mutation": "marker_cell",
+                        "status": "rendered",
+                    }
+                ]
+            }
+        )
+    )
+
+    result = audit.audit_copy_sheet_render_equivalence(report)
+
+    assert result["ready"] is False
+    assert result["result_count"] == 0


### PR DESCRIPTION
## Summary
- add a copy-sheet render-equivalence audit that checks whether a copied sheet has a matching rendered page
- deep-clone form-control ctrlProp parts during sheet copy
- allocate copied form-control shape IDs in Excel-style VML blocks and rewrite copied VML idmap data
- mark hidden-source-sheet render audits inconclusive instead of false failures

## Verification
- cargo test -p wolfxl-structural sheet_copy::tests::clone_with_form_control_properties_allocates_fresh_ctrl_prop --lib
- cargo test -p wolfxl-rels part_id_allocator --lib
- uv run --no-sync pytest tests/test_copy_worksheet_control_props.py tests/test_ooxml_copy_sheet_render_equivalence.py
- uv run --no-sync python scripts/run_ooxml_render_compare.py tests/fixtures/external_oracle --output-dir /tmp/wolfxl-render-excel-intentional-copy-sheet-full-pack-fixed-20260509 --render-engine excel --timeout 180 --mutation copy_first_sheet
- uv run --no-sync python scripts/audit_ooxml_copy_sheet_render_equivalence.py /tmp/wolfxl-render-excel-intentional-copy-sheet-full-pack-fixed-20260509.json --strict

Full-pack audit: 22 results, 20 passed, 2 inconclusive, 0 failures, ready=true.
