### PR TITLE
Require SEC adviser render evidence in completion guard

### DIFF
--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -147,6 +147,7 @@ REQUIRED_CURRENT_EVIDENCE_REPORTS = (
     "ticker_to_gl_strongbox_feature_render_equivalence",
     "ticker_to_gl_strongbox_add_conditional_formatting_render_equivalence",
     "ticker_to_gl_strongbox_copy_remove_sheet_render_equivalence",
+    "sec_adviser_reports_feature_neutral_render_equivalence",
     "public_powerbi_expanded_mutations",
     "synthgl_recursive_mutation_coverage",
     "synthgl_recursive_excel_render_noop_byte_identical",
@@ -224,6 +225,9 @@ OPEN_REQUIREMENTS = (
             "add-conditional-formatting, add-remove-chart, and "
             "copy-remove-sheet render equivalence on five finance-cache "
             "workbooks under the recorded temporary print-area clamp, "
+            "and SEC adviser side evidence separately proves "
+            "add-data-validation, add-remove-chart, and copy-remove-sheet "
+            "render equivalence on four public/regulatory adviser workbooks, "
             "plus expected "
             "visual-delta evidence for "
             "marker-cell, style-cell, insert-tail-row/column, move-marker-range, "


### PR DESCRIPTION
## Summary
- add the SEC adviser feature-neutral render-equivalence report to the completion guard required-current-evidence set
- update the open feature-specific render-equivalence explanation so guard output reflects the newly pinned SEC adviser side evidence

## Validation
- `uv run --no-sync pytest tests/test_ooxml_completion_claim.py -q` -> 5 passed
- `uv run --no-sync python scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict > /tmp/wolfxl-current-evidence-bundle-audit-sec-adviser-required-20260510.json` -> ready=true, 314 reports, 314 producers, 0 issues
- `uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-current-sec-adviser-required-20260510.json` -> current_supported_claim_ready=true, exhaustive_claim_ready=false, missing_requirement_count=4
- `uv run --no-sync python -m py_compile scripts/audit_ooxml_completion_claim.py`