### PR TITLE
Add SEC municipal adviser render evidence

### DIFF
--- a/Plans/ooxml-current-evidence-bundle.json
+++ b/Plans/ooxml-current-evidence-bundle.json
@@ -4671,6 +4671,42 @@
       ]
     },
     {
+      "name": "sec_municipal_adviser_reports_feature_neutral_render_equivalence",
+      "path": "/tmp/wolfxl-sec-municipal-feature-neutral-render-equivalence-20260510.json",
+      "producer": "rm -rf /tmp/wolfxl-sec-municipal-render-sample-20260510 /tmp/wolfxl-render-excel-sec-municipal-feature-neutral-20260510 /tmp/wolfxl-sec-municipal-feature-neutral-render-20260510.json /tmp/wolfxl-sec-municipal-feature-neutral-render-equivalence-20260510.json && mkdir -p /tmp/wolfxl-sec-municipal-render-sample-20260510 && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma010124.xlsx /tmp/wolfxl-sec-municipal-render-sample-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma020124.xlsx /tmp/wolfxl-sec-municipal-render-sample-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma030124.xlsx /tmp/wolfxl-sec-municipal-render-sample-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma040124.xlsx /tmp/wolfxl-sec-municipal-render-sample-20260510/ && (osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_render_compare.py /tmp/wolfxl-sec-municipal-render-sample-20260510 --output-dir /tmp/wolfxl-render-excel-sec-municipal-feature-neutral-20260510 --render-engine excel --mutation add_data_validation --mutation add_remove_chart --mutation copy_remove_sheet --max-pages-per-fixture 1 --page-selection first-pages --timeout 180 > /tmp/wolfxl-sec-municipal-feature-neutral-render-20260510.json && uv run --no-sync python scripts/audit_ooxml_no_visual_change_render_equivalence.py /tmp/wolfxl-render-excel-sec-municipal-feature-neutral-20260510/render-compare-report.json --mutation add_data_validation --mutation add_remove_chart --mutation copy_remove_sheet --timeout 180 --strict > /tmp/wolfxl-sec-municipal-feature-neutral-render-equivalence-20260510.json",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "render_engine", "equals": "excel"},
+        {"path": "mutations", "equals": ["add_data_validation", "add_remove_chart", "copy_remove_sheet"]},
+        {"path": "observed_mutations", "equals": ["add_data_validation", "add_remove_chart", "copy_remove_sheet"]},
+        {"path": "result_count", "equals": 12},
+        {"path": "passed_count", "equals": 12},
+        {"path": "failure_count", "equals": 0},
+        {"path": "inconclusive_count", "equals": 0},
+        {"path": "skipped_count", "equals": 0},
+        {"path": "results.0.max_normalized_rmse", "equals": 0.0},
+        {"path": "results.0.message", "contains": "render equivalent"}
+      ]
+    },
+    {
+      "name": "sec_municipal_adviser_reports_add_conditional_formatting_render_equivalence",
+      "path": "/tmp/wolfxl-sec-municipal-add-cf-render-equivalence-20260510.json",
+      "producer": "rm -rf /tmp/wolfxl-sec-municipal-render-sample-cf-20260510 /tmp/wolfxl-render-excel-sec-municipal-add-cf-20260510 /tmp/wolfxl-sec-municipal-add-cf-render-20260510.json /tmp/wolfxl-sec-municipal-add-cf-render-equivalence-20260510.json && mkdir -p /tmp/wolfxl-sec-municipal-render-sample-cf-20260510 && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma010124.xlsx /tmp/wolfxl-sec-municipal-render-sample-cf-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma020124.xlsx /tmp/wolfxl-sec-municipal-render-sample-cf-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma030124.xlsx /tmp/wolfxl-sec-municipal-render-sample-cf-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma040124.xlsx /tmp/wolfxl-sec-municipal-render-sample-cf-20260510/ && (osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_render_compare.py /tmp/wolfxl-sec-municipal-render-sample-cf-20260510 --output-dir /tmp/wolfxl-render-excel-sec-municipal-add-cf-20260510 --render-engine excel --mutation add_conditional_formatting --max-pages-per-fixture 1 --page-selection first-pages --timeout 180 > /tmp/wolfxl-sec-municipal-add-cf-render-20260510.json && uv run --no-sync python scripts/audit_ooxml_no_visual_change_render_equivalence.py /tmp/wolfxl-render-excel-sec-municipal-add-cf-20260510/render-compare-report.json --mutation add_conditional_formatting --timeout 180 --strict > /tmp/wolfxl-sec-municipal-add-cf-render-equivalence-20260510.json",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "render_engine", "equals": "excel"},
+        {"path": "mutations", "equals": ["add_conditional_formatting"]},
+        {"path": "observed_mutations", "equals": ["add_conditional_formatting"]},
+        {"path": "result_count", "equals": 4},
+        {"path": "passed_count", "equals": 4},
+        {"path": "failure_count", "equals": 0},
+        {"path": "inconclusive_count", "equals": 0},
+        {"path": "skipped_count", "equals": 0},
+        {"path": "results.0.max_normalized_rmse", "equals": 0.0},
+        {"path": "results.0.message", "contains": "render equivalent"}
+      ]
+    },
+    {
       "name": "sec_adviser_reports_feature_neutral_render_equivalence",
       "path": "/tmp/wolfxl-sec-adviser-feature-neutral-render-equivalence-20260510.json",
       "producer": "rm -rf /tmp/wolfxl-sec-adviser-render-sample-20260510 /tmp/wolfxl-render-excel-sec-adviser-feature-neutral-20260510 /tmp/wolfxl-sec-adviser-feature-neutral-render-20260510.json /tmp/wolfxl-sec-adviser-feature-neutral-render-equivalence-20260510.json && mkdir -p /tmp/wolfxl-sec-adviser-render-sample-20260510 && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_investment_advisers/ia080124-exempt.xlsx /tmp/wolfxl-sec-adviser-render-sample-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_investment_advisers/ia08102023-exempt.xlsx /tmp/wolfxl-sec-adviser-render-sample-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma080124.xlsx /tmp/wolfxl-sec-adviser-render-sample-20260510/ && cp /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors/ma080125.xlsx /tmp/wolfxl-sec-adviser-render-sample-20260510/ && (osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_render_compare.py /tmp/wolfxl-sec-adviser-render-sample-20260510 --output-dir /tmp/wolfxl-render-excel-sec-adviser-feature-neutral-20260510 --render-engine excel --mutation add_data_validation --mutation add_remove_chart --mutation copy_remove_sheet --max-pages-per-fixture 1 --page-selection first-pages --timeout 180 > /tmp/wolfxl-sec-adviser-feature-neutral-render-20260510.json && uv run --no-sync python scripts/audit_ooxml_no_visual_change_render_equivalence.py /tmp/wolfxl-render-excel-sec-adviser-feature-neutral-20260510/render-compare-report.json --mutation add_data_validation --mutation add_remove_chart --mutation copy_remove_sheet --timeout 180 --strict > /tmp/wolfxl-sec-adviser-feature-neutral-render-equivalence-20260510.json",

--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -154,6 +154,8 @@ REQUIRED_CURRENT_EVIDENCE_REPORTS = (
     "sec_adviser_reports_add_conditional_formatting_render_equivalence",
     "sec_investment_mgmt_feature_neutral_render_equivalence",
     "sec_investment_mgmt_add_conditional_formatting_render_equivalence",
+    "sec_municipal_adviser_reports_feature_neutral_render_equivalence",
+    "sec_municipal_adviser_reports_add_conditional_formatting_render_equivalence",
     "public_powerbi_expanded_mutations",
     "synthgl_recursive_mutation_coverage",
     "synthgl_recursive_excel_render_noop_byte_identical",
@@ -240,6 +242,10 @@ OPEN_REQUIREMENTS = (
             "add-data-validation, add-conditional-formatting, add-remove-chart, "
             "and copy-remove-sheet render equivalence on five "
             "public/regulatory investment-management workbooks, "
+            "and SEC municipal adviser sidecar evidence separately proves "
+            "add-data-validation, add-conditional-formatting, add-remove-chart, "
+            "and copy-remove-sheet render equivalence on four "
+            "public/regulatory municipal-adviser workbooks, "
             "plus expected "
             "visual-delta evidence for "
             "marker-cell, style-cell, insert-tail-row/column, move-marker-range, "


### PR DESCRIPTION
## Summary
- add SEC municipal adviser render-equivalence sidecars for add-data-validation, add-remove-chart, copy-remove-sheet, and add-conditional-formatting mutations
- require the new municipal reports in the current-supported OOXML completion-claim audit
- update the open render-equivalence requirement text to call out the new municipal-adviser public/regulatory coverage

## Verification
- SEC municipal feature-neutral render audit: 12/12 passed, 0 failures, 0 inconclusive
- SEC municipal add-conditional-formatting render audit: 4/4 passed, 0 failures, 0 inconclusive
- jq empty Plans/ooxml-current-evidence-bundle.json
- uv run --no-sync python scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current
- uv run --no-sync pytest tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q
- git diff --check