### PR TITLE
Add SEC municipal adviser corpus buckets

### DIFF
--- a/Plans/ooxml-current-evidence-bundle.json
+++ b/Plans/ooxml-current-evidence-bundle.json
@@ -4389,6 +4389,23 @@
       ]
     },
     {
+      "name": "sec_municipal_advisers_corpus_buckets",
+      "path": "/tmp/wolfxl-corpus-buckets-sec-municipal-advisers-20260510.json",
+      "producer": "uv run --no-sync python scripts/audit_ooxml_corpus_buckets.py /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors --json > /tmp/wolfxl-corpus-buckets-sec-municipal-advisers-20260510.json",
+      "expect": [
+        {"path": "ready", "equals": false},
+        {"path": "workbook_count", "equals": 29},
+        {"path": "skipped_workbook_count", "equals": 0},
+        {"path": "missing_buckets", "equals": ["chart_or_chart_style", "external_link", "external_tool_authored", "macro_vba", "powerpivot_data_model", "slicer_or_timeline"]},
+        {"path": "bucket_fixtures.excel_authored", "length_at_least": 29},
+        {"path": "bucket_fixtures.conditional_formatting_extension", "length_at_least": 29},
+        {"path": "bucket_fixtures.table_structured_ref_or_validation", "length_at_least": 20},
+        {"path": "bucket_fixtures.workbook_global_state", "length_at_least": 29},
+        {"path": "bucket_fixtures.drawing_comment_or_media", "length_at_least": 1},
+        {"path": "bucket_fixtures.embedded_object_or_control", "length_at_least": 1}
+      ]
+    },
+    {
       "name": "sec_investment_mgmt_gap_radar",
       "path": "/tmp/wolfxl-gap-radar-sec-investment-mgmt-20260510.json",
       "producer": "uv run --no-sync python scripts/audit_ooxml_gap_radar.py /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_investment_mgmt --json --strict > /tmp/wolfxl-gap-radar-sec-investment-mgmt-20260510.json",

--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -89,6 +89,8 @@ REQUIRED_CURRENT_EVIDENCE_REPORTS = (
     "external_oracle_corpus_diversity",
     "corpus_portfolio_diversity",
     "external_oracle_gap_radar",
+    "sec_municipal_advisers_gap_radar",
+    "sec_municipal_advisers_corpus_buckets",
     "sec_investment_mgmt_gap_radar",
     "sec_investment_mgmt_corpus_buckets",
     "synthgl_recursive_gap_radar",
@@ -168,8 +170,9 @@ OPEN_REQUIREMENTS = (
         "status": "open",
         "reason": (
             "The current corpus portfolio spans 321 unique readable workbooks across 24 "
-            "source reports, including the SEC investment-management public/regulatory "
-            "sidecar, and covers all required diversity buckets, but it is still not "
+            "source reports, includes standalone SEC municipal-adviser and "
+            "SEC investment-management public/regulatory sidecars, and covers all "
+            "required diversity buckets, but it is still not "
             "customer-scale or random real-world Excel evidence."
         ),
     },


### PR DESCRIPTION
## Summary
- add a standalone 29-workbook SEC municipal adviser corpus-bucket sidecar
- require both the existing municipal gap-radar sidecar and the new bucket sidecar in the current-supported completion-claim gate
- update the broader corpus requirement text to call out standalone municipal-adviser and investment-management regulatory sidecars while keeping the requirement open

## Verification
- uv run --no-sync python scripts/audit_ooxml_corpus_buckets.py /Users/wolfgangschoenberger/Projects/SynthGL/data/rwd_validation/sec_municipal_advisors --json
- jq empty Plans/ooxml-current-evidence-bundle.json
- uv run --no-sync python scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current
- uv run --no-sync pytest tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q
- git diff --check