### PR TITLE
Add rename sheet prompt and control evidence

### DIFF
--- a/Plans/ooxml-current-evidence-bundle.json
+++ b/Plans/ooxml-current-evidence-bundle.json
@@ -6007,6 +6007,111 @@
       ]
     },
     {
+      "name": "excel_ui_interaction_rename_macro_disable_button",
+      "path": "/tmp/wolfxl-ui-interaction-rename-macro-20260511/interactive-probe-report.json",
+      "producer": "(osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_interactive_probe.py tests/fixtures/external_oracle --output-dir /tmp/wolfxl-ui-interaction-rename-macro-20260511 --probe-kind excel_ui_interaction --probe macro_project_presence --mutation rename_first_sheet --fixture real-excel-macro-basic.xlsm --timeout 120 > /tmp/wolfxl-ui-interaction-rename-macro-20260511.stdout.json",
+      "expect": [
+        {"path": "completed", "equals": true},
+        {"path": "failure_count", "equals": 0},
+        {"path": "result_count", "equals": 1},
+        {"path": "probe_kind", "equals": "excel_ui_interaction"},
+        {"path": "mutation", "equals": "rename_first_sheet"},
+        {"path": "results.0.fixture", "equals": "real-excel-macro-basic.xlsm"},
+        {"path": "results.0.probe", "equals": "macro_project_presence"},
+        {"path": "results.0.mutation", "equals": "rename_first_sheet"},
+        {"path": "results.0.status", "equals": "passed"},
+        {"path": "results.0.ui_actions", "contains": "clicked button: Disable Macros"}
+      ]
+    },
+    {
+      "name": "excel_ui_interaction_rename_control_clicks",
+      "path": "/tmp/wolfxl-ui-interaction-rename-control-clicks-20260511/interactive-probe-report.json",
+      "producer": "(osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_interactive_probe.py tests/fixtures/external_oracle --output-dir /tmp/wolfxl-ui-interaction-rename-control-clicks-20260511 --probe-kind excel_ui_interaction --probe embedded_control_openability --mutation rename_first_sheet --fixture real-excel-control-props-basic.xlsx --fixture umya-control-props-basic.xlsx --timeout 120 > /tmp/wolfxl-ui-interaction-rename-control-clicks-20260511.stdout.json",
+      "expect": [
+        {"path": "completed", "equals": true},
+        {"path": "failure_count", "equals": 0},
+        {"path": "result_count", "equals": 2},
+        {"path": "probe_kind", "equals": "excel_ui_interaction"},
+        {"path": "mutation", "equals": "rename_first_sheet"},
+        {"path": "results.0.fixture", "equals": "umya-control-props-basic.xlsx"},
+        {"path": "results.0.probe", "equals": "embedded_control_openability"},
+        {"path": "results.0.status", "equals": "passed"},
+        {"path": "results.0.ui_actions", "contains": "clicked Excel embedded/control object"},
+        {"path": "results.1.fixture", "equals": "real-excel-control-props-basic.xlsx"},
+        {"path": "results.1.probe", "equals": "embedded_control_openability"},
+        {"path": "results.1.status", "equals": "passed"},
+        {"path": "results.1.ui_actions", "contains": "clicked Excel embedded/control object"}
+      ]
+    },
+    {
+      "name": "excel_ui_interaction_rename_external_link_current_prompt",
+      "path": "/tmp/wolfxl-ui-interaction-rename-external-link-current-prompt-20260511/interactive-probe-report.json",
+      "producer": "(osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_interactive_probe.py tests/fixtures/external_oracle --output-dir /tmp/wolfxl-ui-interaction-rename-external-link-current-prompt-20260511 --probe-kind excel_ui_interaction --probe external_link_update_prompt --external-link-prompt-mode current --mutation rename_first_sheet --fixture real-excel-external-link-basic.xlsx --timeout 45 > /tmp/wolfxl-ui-interaction-rename-external-link-current-prompt-20260511.stdout.json",
+      "expect": [
+        {"path": "completed", "equals": true},
+        {"path": "failure_count", "equals": 0},
+        {"path": "result_count", "equals": 1},
+        {"path": "probe_kind", "equals": "excel_ui_interaction"},
+        {"path": "external_link_prompt_mode", "equals": "current"},
+        {"path": "mutation", "equals": "rename_first_sheet"},
+        {"path": "results.0.fixture", "equals": "real-excel-external-link-basic.xlsx"},
+        {"path": "results.0.probe", "equals": "external_link_update_prompt"},
+        {"path": "results.0.mutation", "equals": "rename_first_sheet"},
+        {"path": "results.0.status", "equals": "passed"}
+      ]
+    },
+    {
+      "name": "excel_ui_interaction_rename_powerview_open_readonly",
+      "path": "/tmp/wolfxl-ui-interaction-rename-powerview-open-readonly-20260511/interactive-probe-report.json",
+      "producer": "(osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_interactive_probe.py tests/fixtures/powerpivot_variants --output-dir /tmp/wolfxl-ui-interaction-rename-powerview-open-readonly-20260511 --probe-kind excel_ui_interaction --probe unsupported_content_prompt --mutation rename_first_sheet --fixture real-excel-powerpivot-contoso-pnl.xlsx --timeout 120 > /tmp/wolfxl-ui-interaction-rename-powerview-open-readonly-20260511.stdout.json",
+      "expect": [
+        {"path": "completed", "equals": true},
+        {"path": "failure_count", "equals": 0},
+        {"path": "result_count", "equals": 1},
+        {"path": "probe_kind", "equals": "excel_ui_interaction"},
+        {"path": "mutation", "equals": "rename_first_sheet"},
+        {"path": "results.0.fixture", "equals": "real-excel-powerpivot-contoso-pnl.xlsx"},
+        {"path": "results.0.probe", "equals": "unsupported_content_prompt"},
+        {"path": "results.0.mutation", "equals": "rename_first_sheet"},
+        {"path": "results.0.status", "equals": "passed"},
+        {"path": "results.0.ui_actions", "contains": "clicked button: Open as Read-Only"}
+      ]
+    },
+    {
+      "name": "excel_ui_interaction_rename_external_oracle_prompt_control_evidence",
+      "path": "/tmp/wolfxl-ui-interaction-evidence-rename-external-oracle-prompt-control-20260511.json",
+      "producer": "uv run --no-sync python scripts/audit_ooxml_interactive_evidence.py tests/fixtures/external_oracle --probe-kind excel_ui_interaction --probe macro_project_presence --probe embedded_control_openability --probe external_link_update_prompt --report /tmp/wolfxl-ui-interaction-rename-macro-20260511/interactive-probe-report.json --report /tmp/wolfxl-ui-interaction-rename-control-clicks-20260511/interactive-probe-report.json --report /tmp/wolfxl-ui-interaction-rename-external-link-current-prompt-20260511/interactive-probe-report.json --strict > /tmp/wolfxl-ui-interaction-evidence-rename-external-oracle-prompt-control-20260511.json",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "probe_kind", "equals": "excel_ui_interaction"},
+        {"path": "required_probes", "equals": ["macro_project_presence", "embedded_control_openability", "external_link_update_prompt"]},
+        {"path": "fixture_count", "equals": 22},
+        {"path": "report_count", "equals": 3},
+        {"path": "incomplete_report_count", "equals": 0},
+        {"path": "probes.embedded_control_openability.status", "equals": "clear"},
+        {"path": "probes.embedded_control_openability.passed_fixtures", "equals": ["umya-control-props-basic.xlsx", "real-excel-control-props-basic.xlsx"]},
+        {"path": "probes.external_link_update_prompt.status", "equals": "clear"},
+        {"path": "probes.external_link_update_prompt.passed_fixtures", "equals": ["real-excel-external-link-basic.xlsx"]},
+        {"path": "probes.macro_project_presence.status", "equals": "clear"},
+        {"path": "probes.macro_project_presence.passed_fixtures", "equals": ["real-excel-macro-basic.xlsm"]}
+      ]
+    },
+    {
+      "name": "excel_ui_interaction_rename_powerview_evidence",
+      "path": "/tmp/wolfxl-ui-interaction-evidence-rename-powerview-open-readonly-20260511.json",
+      "producer": "uv run --no-sync python scripts/audit_ooxml_interactive_evidence.py tests/fixtures/powerpivot_variants --probe-kind excel_ui_interaction --probe unsupported_content_prompt --report /tmp/wolfxl-ui-interaction-rename-powerview-open-readonly-20260511/interactive-probe-report.json --strict > /tmp/wolfxl-ui-interaction-evidence-rename-powerview-open-readonly-20260511.json",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "probe_kind", "equals": "excel_ui_interaction"},
+        {"path": "required_probes", "equals": ["unsupported_content_prompt"]},
+        {"path": "fixture_count", "equals": 1},
+        {"path": "report_count", "equals": 1},
+        {"path": "incomplete_report_count", "equals": 0},
+        {"path": "probes.unsupported_content_prompt.status", "equals": "clear"},
+        {"path": "probes.unsupported_content_prompt.passed_fixtures", "equals": ["real-excel-powerpivot-contoso-pnl.xlsx"]}
+      ]
+    },
+    {
       "name": "corpus_portfolio_diversity",
       "path": "/tmp/wolfxl-corpus-portfolio-buckets-with-census-sitc-20260511.json",
       "producer": "uv run --no-sync python scripts/audit_ooxml_corpus_portfolio.py /tmp/wolfxl-corpus-buckets-external-oracle-final.json /tmp/wolfxl-corpus-buckets-umya-test-files.json /tmp/wolfxl-corpus-buckets-synthgl-recursive-python-metadata.json /tmp/wolfxl-corpus-buckets-synthgl-real-world-ingestion-20260509.json /tmp/wolfxl-corpus-buckets-synthgl-cds-case-study-20260509.json /tmp/wolfxl-corpus-buckets-calamine-tests-20260508.json /tmp/wolfxl-corpus-buckets-ilpa-20260509.json /tmp/wolfxl-corpus-buckets-wdesk-wbd-20260509.json /tmp/wolfxl-corpus-buckets-bf30-remaining-20260509.json /tmp/wolfxl-corpus-buckets-blind-holdout-20260509.json /tmp/wolfxl-corpus-buckets-rescue-downloads-20260509.json /tmp/wolfxl-corpus-buckets-sec-edgar-20260509.json /tmp/wolfxl-corpus-buckets-iran-osint-20260509.json /tmp/wolfxl-corpus-buckets-powerpivot-variants-20260509.json /tmp/wolfxl-corpus-buckets-slicer-timeline-variants-20260509.json /tmp/wolfxl-corpus-buckets-excelbench-core-20260509.json /tmp/wolfxl-corpus-buckets-excelbench-external-validated-20260509.json /tmp/wolfxl-corpus-buckets-excelbench-real-world-20260509.json /tmp/wolfxl-corpus-buckets-spreadsheet-peek-examples-20260509.json /tmp/wolfxl-corpus-buckets-ticker-to-gl-20260509.json /tmp/wolfxl-corpus-buckets-synthgl-docs-examples-excel-20260509.json /tmp/wolfxl-corpus-buckets-fintech-hackathon-demo-20260510.json /tmp/wolfxl-corpus-buckets-sec-adviser-reports-sample-20260510.json /tmp/wolfxl-corpus-buckets-sec-municipal-advisers-20260510.json /tmp/wolfxl-corpus-buckets-sec-investment-mgmt-20260510.json /tmp/wolfxl-corpus-buckets-domain-ground-truth-valid-20260510.json /tmp/wolfxl-corpus-buckets-irs-soi-20260511.json /tmp/wolfxl-corpus-buckets-bea-gdp-20260511.json /tmp/wolfxl-corpus-buckets-usda-ers-county-20260511.json /tmp/wolfxl-corpus-buckets-eia-energy-20260511.json /tmp/wolfxl-corpus-buckets-census-sitc-renderable-20260511.json --min-sources 31 --min-workbooks 401 --strict > /tmp/wolfxl-corpus-portfolio-buckets-with-census-sitc-20260511.json",

--- a/Plans/real-world-excel-fidelity-gap-discovery.md
+++ b/Plans/real-world-excel-fidelity-gap-discovery.md
@@ -613,6 +613,16 @@ and clicked the May timeline month in `real-excel-timeline-slicer.xlsx`. Both
 strict audit reports are `ready=true` with 5 raw UI reports, 0 failures, and 0
 incomplete reports.
 
+Latest rename-sheet prompt/control interaction increment adds
+`/tmp/wolfxl-ui-interaction-evidence-rename-external-oracle-prompt-control-20260511.json`
+and `/tmp/wolfxl-ui-interaction-evidence-rename-powerview-open-readonly-20260511.json`:
+after a WolfXL `rename_first_sheet` save, Microsoft Excel handled the macro
+`Disable Macros` prompt, clicked both real-Excel and umya embedded controls,
+preserved the current-setting external-link prompt path while keeping external
+link parts present, and opened the PowerView workbook as read-only while keeping
+the unsupported-content marker present. Both strict audit reports are
+`ready=true` with 4 raw UI reports, 0 failures, and 0 incomplete reports.
+
 Current conclusion:
 
 - The repo can honestly claim: **no known fidelity gap in the currently pinned


### PR DESCRIPTION
## Summary
- pin Excel UI-interaction probes after a WolfXL rename-first-sheet save for prompt/control surfaces
- cover macro prompt handling, embedded/control clicks, external-link current-setting preservation, and PowerView read-only prompt handling
- document the evidence while keeping the exhaustive no-gaps claim intentionally blocked

## Validation
- uv run --no-sync python -m json.tool Plans/ooxml-current-evidence-bundle.json >/dev/null
- uv run --no-sync python scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict > /tmp/wolfxl-current-evidence-bundle-audit-rename-prompt-control-20260511.json
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-current-rename-prompt-control-20260511.json
- uv run --no-sync pytest tests/test_ooxml_evidence_bundle.py tests/test_ooxml_completion_claim.py tests/test_ooxml_interactive_evidence.py -q
- git diff --check