### PR TITLE
chore: expose completion guard missing ids

### DIFF
--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -383,6 +383,7 @@ def audit_completion_claim(bundle_path: Path) -> dict:
         "current_supported_claim_ready": current_supported_claim_ready,
         "criteria": criteria,
         "missing_requirement_count": len(missing),
+        "missing_requirement_ids": [criterion["id"] for criterion in missing],
         "missing_requirements": missing,
         "bundle_audit": {
             "ready": bundle_ready,

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -33,6 +33,12 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
     assert report["exhaustive_claim_ready"] is False
     assert report["bundle_audit"]["ready"] is True
     assert report["missing_requirement_count"] == 4
+    assert report["missing_requirement_ids"] == [
+        "broader_real_world_corpus_diversity",
+        "feature_specific_intentional_render_equivalence",
+        "broader_click_level_interaction_variants",
+        "future_surface_exhaustiveness",
+    ]
     assert {
         requirement["id"] for requirement in report["missing_requirements"]
     } == {


### PR DESCRIPTION
## Summary
- add a top-level `missing_requirement_ids` array to the completion-claim audit JSON
- cover the field in the focused completion-claim test
- keep `--strict-current-evidence` behavior unchanged: current supported evidence can pass while the exhaustive claim remains false

## Validation
- `uv run --no-sync pytest tests/test_ooxml_completion_claim.py -q`
- `uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-current-missing-ids-20260511.json`
- `git diff --check`
