### PR TITLE
Require latest OOXML evidence in completion guard

### DIFF
--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -167,6 +167,10 @@ REQUIRED_CURRENT_EVIDENCE_REPORTS = (
     "sec_municipal_adviser_reports_feature_neutral_render_equivalence",
     "sec_municipal_adviser_reports_add_conditional_formatting_render_equivalence",
     "domain_ground_truth_neutral_render_equivalence",
+    "pivot_slicer_structural_render_equivalence",
+    "local_project_holdouts_small_neutral_render_equivalence",
+    "current_excel_16_108_delete_first_row_broad_external_tool_slicer_boundary",
+    "current_excel_16_108_delete_first_col_broad_external_tool_slicer_boundary",
     "public_powerbi_expanded_mutations",
     "synthgl_recursive_mutation_coverage",
     "synthgl_recursive_excel_render_noop_byte_identical",
@@ -264,6 +268,12 @@ OPEN_REQUIREMENTS = (
             "add-data-validation, add-conditional-formatting, add-remove-chart, "
             "and copy-remove-sheet render equivalence on all 29 "
             "public/regulatory municipal-adviser workbooks, "
+            "pivot/slicer structural side evidence separately proves "
+            "rename-sheet and copy-remove-sheet render equivalence on three "
+            "high-risk pivot/slicer fixtures, and local-project holdout side "
+            "evidence separately proves add-data-validation and "
+            "copy-remove-sheet render equivalence on two representative "
+            "local workbooks, "
             "plus expected "
             "visual-delta evidence for "
             "marker-cell, style-cell, insert-tail-row/column, move-marker-range, "
@@ -286,9 +296,11 @@ OPEN_REQUIREMENTS = (
             "Plans/real-world-excel-fidelity-gap-discovery.md. This still is "
             "not exhaustive: current Excel 16.108 rechecks show some source "
             "table-slicer, timeline, and list-box UI paths can complete actions "
-            "without persisting a state change in this environment, and broader "
-            "slicer, timeline, embedded-control, and prompt variants remain "
-            "unexhausted."
+            "without persisting a state change in this environment, and pinned "
+            "delete-first-row/column broad UI boundary reports still expose one "
+            "external-tool slicer click that is not observed after each "
+            "destructive-axis edit. Broader slicer, timeline, embedded-control, "
+            "and prompt variants remain unexhausted."
         ),
     },
     {

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -53,6 +53,27 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
         if requirement["id"] == "broader_real_world_corpus_diversity"
     )
     assert "11 unique readable workbooks across 3 source reports" in corpus_requirement["reason"]
+    required_reports = next(
+        criterion
+        for criterion in report["criteria"]
+        if criterion["id"] == "current_evidence_required_reports_present"
+    )
+    assert required_reports["evidence"]["missing_reports"] == []
+    assert required_reports["evidence"]["required_report_count"] == len(
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "pivot_slicer_structural_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "local_project_holdouts_small_neutral_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "current_excel_16_108_delete_first_row_broad_external_tool_slicer_boundary" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "current_excel_16_108_delete_first_col_broad_external_tool_slicer_boundary" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
 
 
 def test_completion_claim_audit_requires_named_current_evidence_reports(


### PR DESCRIPTION
## Summary
- require the latest local-holdout and pivot/slicer render-equivalence artifacts in the completion guard
- require the destructive-axis broad UI boundary reports as current evidence dependencies
- refresh the open-requirement wording so the guard explains both the added proof and the remaining boundaries

## Validation
- `uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-current-guard-latest-evidence-20260511.json`
- `uv run --no-sync pytest tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q`
- `git diff --check`

## Results
- completion guard: current_supported_claim_ready=true, exhaustive_claim_ready=false, missing_requirement_count=4
- required current-evidence reports: 153 present / 153 required
