### PR TITLE
Require public statistics OOXML evidence in completion guard

### DIFF
--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -93,6 +93,23 @@ REQUIRED_CURRENT_EVIDENCE_REPORTS = (
     "sec_municipal_advisers_corpus_buckets",
     "sec_investment_mgmt_gap_radar",
     "sec_investment_mgmt_corpus_buckets",
+    "irs_soi_public_corpus_buckets",
+    "irs_soi_public_gap_radar",
+    "irs_soi_public_quick_mutation_report",
+    "bea_gdp_public_corpus_buckets",
+    "bea_gdp_public_gap_radar",
+    "bea_gdp_public_quick_mutation_report",
+    "usda_ers_county_public_corpus_buckets",
+    "usda_ers_county_public_gap_radar",
+    "usda_ers_county_public_quick_mutation_report",
+    "eia_energy_public_corpus_buckets",
+    "eia_energy_public_gap_radar",
+    "eia_energy_public_quick_mutation_report",
+    "eia_energy_public_neutral_render_equivalence",
+    "census_sitc_renderable_corpus_buckets",
+    "census_sitc_renderable_gap_radar",
+    "census_sitc_renderable_quick_mutation_report",
+    "census_sitc_renderable_neutral_render_equivalence",
     "synthgl_recursive_gap_radar",
     "umya_test_files_gap_radar",
     "umya_test_files_quick_plus_structural_mutation_coverage",
@@ -337,9 +354,10 @@ def _open_requirements(bundle_audit: dict) -> list[dict]:
                 f"workbooks across {source_count} source reports, including the "
                 "domain-ground-truth public workbook sidecar, standalone SEC "
                 "municipal-adviser and SEC investment-management public/regulatory "
-                "sidecars, public-statistics sidecars, and all required "
-                "diversity buckets, but it is still not customer-scale or random "
-                "real-world Excel evidence."
+                "sidecars, IRS SOI, BEA GDP, USDA ERS county, EIA energy, and "
+                "Census SITC public-statistics sidecars, and all required diversity "
+                "buckets, but it is still not customer-scale or random real-world "
+                "Excel evidence."
             )
             break
     return requirements

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -74,6 +74,21 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
     assert "current_excel_16_108_delete_first_col_broad_external_tool_slicer_boundary" in (
         completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
     )
+    assert "irs_soi_public_quick_mutation_report" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "bea_gdp_public_quick_mutation_report" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "usda_ers_county_public_quick_mutation_report" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "eia_energy_public_neutral_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "census_sitc_renderable_neutral_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
 
 
 def test_completion_claim_audit_requires_named_current_evidence_reports(


### PR DESCRIPTION
## Summary
- require IRS SOI, BEA GDP, USDA ERS county, EIA energy, and Census SITC public-statistics evidence reports in the current OOXML completion guard
- update the broader corpus-diversity open requirement text to name those public-statistics sidecars explicitly
- extend completion-claim tests so the guard cannot regress without the public-statistics slice

## Validation
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-public-statistics-required-20260511.json
- uv run --no-sync pytest tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q
- git diff --check

## Audit Result
- current_supported_claim_ready: true
- exhaustive_claim_ready: false
- missing_requirement_count: 4