### PR TITLE
docs: pin random holdout render boundary evidence

### DIFF
--- a/Plans/ooxml-current-evidence-bundle.json
+++ b/Plans/ooxml-current-evidence-bundle.json
@@ -7960,6 +7960,71 @@
       ]
     },
     {
+      "name": "random_corpus_holdout_20_render_boundary",
+      "path": "/tmp/wolfxl-random-holdout-20-render-boundary-20260511.json",
+      "producer": "rm -rf /tmp/wolfxl-random-corpus-holdout-20-stage-20260511 /tmp/wolfxl-render-excel-random-holdout-20-neutral-features-clamped-20260511 && uv run --no-sync python scripts/audit_ooxml_random_corpus_holdout.py /tmp/wolfxl-corpus-portfolio-buckets-with-fed-aea-20260511.json --sample-size 20 --min-sample-size 20 --min-sources 8 --seed wolfxl-random-holdout-render-20260511-v15 --stage-dir /tmp/wolfxl-random-corpus-holdout-20-stage-20260511 --strict > /tmp/wolfxl-random-corpus-holdout-20-staged-render-20260511.json && (osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_render_compare.py /tmp/wolfxl-random-corpus-holdout-20-stage-20260511 --output-dir /tmp/wolfxl-render-excel-random-holdout-20-neutral-features-clamped-20260511 --render-engine excel --mutation add_data_validation --mutation add_conditional_formatting --mutation add_remove_chart --mutation copy_remove_sheet --max-pages-per-fixture 1 --page-selection first-pages --excel-print-area '$A$1:$K$80' --timeout 120 > /tmp/wolfxl-render-excel-random-holdout-20-neutral-features-clamped-20260511.stdout.json || true; uv run --no-sync python scripts/summarize_ooxml_render_boundary.py /tmp/wolfxl-random-corpus-holdout-20-staged-render-20260511.json /tmp/wolfxl-render-excel-random-holdout-20-neutral-features-clamped-20260511/render-compare-report.json --strict > /tmp/wolfxl-random-holdout-20-render-boundary-20260511.json",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "seed", "equals": "wolfxl-random-holdout-render-20260511-v15"},
+        {"path": "sample_size", "equals": 20},
+        {"path": "selected_count", "equals": 20},
+        {"path": "selected_source_count", "equals": 14},
+        {"path": "selected_bucket_counts.excel_authored", "equals": 20},
+        {"path": "selected_bucket_counts.external_tool_authored", "equals": 1},
+        {"path": "selected_bucket_counts.chart_or_chart_style", "equals": 1},
+        {"path": "selected_bucket_counts.table_structured_ref_or_validation", "equals": 4},
+        {"path": "render_engine", "equals": "excel"},
+        {"path": "excel_print_area", "equals": "$A$1:$K$80"},
+        {"path": "mutations", "equals": ["add_data_validation", "add_conditional_formatting", "add_remove_chart", "copy_remove_sheet"]},
+        {"path": "render_result_count", "equals": 80},
+        {"path": "render_failure_count", "equals": 8},
+        {"path": "status_counts.failed", "equals": 8},
+        {"path": "status_counts.sampled_rendered", "equals": 72},
+        {"path": "excluded_from_renderable_subset", "length": 2},
+        {"path": "excluded_from_renderable_subset.0.fixture", "equals": "001-d662d4eae9-Project_Newlin_QofE_Databook.xlsx"},
+        {"path": "excluded_from_renderable_subset.1.fixture", "equals": "011-3bb7f45268-empty_s_attribute.xlsx"},
+        {"path": "renderable_subset_count", "equals": 18}
+      ]
+    },
+    {
+      "name": "random_corpus_holdout_20_renderable_18_neutral_render_smoke",
+      "path": "/tmp/wolfxl-render-excel-random-holdout-20-renderable-18-neutral-features-20260511/render-compare-report.json",
+      "producer": "rm -rf /tmp/wolfxl-random-corpus-holdout-20-stage-20260511 /tmp/wolfxl-random-corpus-holdout-20-renderable-18-stage-20260511 /tmp/wolfxl-render-excel-random-holdout-20-renderable-18-neutral-features-20260511 && uv run --no-sync python scripts/audit_ooxml_random_corpus_holdout.py /tmp/wolfxl-corpus-portfolio-buckets-with-fed-aea-20260511.json --sample-size 20 --min-sample-size 20 --min-sources 8 --seed wolfxl-random-holdout-render-20260511-v15 --stage-dir /tmp/wolfxl-random-corpus-holdout-20-stage-20260511 --strict > /tmp/wolfxl-random-corpus-holdout-20-staged-render-20260511.json && mkdir -p /tmp/wolfxl-random-corpus-holdout-20-renderable-18-stage-20260511 && find /tmp/wolfxl-random-corpus-holdout-20-stage-20260511 -maxdepth 1 -type f -name '*.xlsx' ! -name '001-d662d4eae9-Project_Newlin_QofE_Databook.xlsx' ! -name '011-3bb7f45268-empty_s_attribute.xlsx' -exec cp {} /tmp/wolfxl-random-corpus-holdout-20-renderable-18-stage-20260511/ \\; && (osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_render_compare.py /tmp/wolfxl-random-corpus-holdout-20-renderable-18-stage-20260511 --output-dir /tmp/wolfxl-render-excel-random-holdout-20-renderable-18-neutral-features-20260511 --render-engine excel --mutation add_data_validation --mutation add_conditional_formatting --mutation add_remove_chart --mutation copy_remove_sheet --max-pages-per-fixture 1 --page-selection first-pages --excel-print-area '$A$1:$K$80' --timeout 120 > /tmp/wolfxl-render-excel-random-holdout-20-renderable-18-neutral-features-20260511.stdout.json",
+      "expect": [
+        {"path": "render_engine", "equals": "excel"},
+        {"path": "excel_print_area", "equals": "$A$1:$K$80"},
+        {"path": "mutations", "equals": ["add_data_validation", "add_conditional_formatting", "add_remove_chart", "copy_remove_sheet"]},
+        {"path": "page_selection", "equals": "first-pages"},
+        {"path": "max_pages_per_fixture", "equals": 1},
+        {"path": "result_count", "equals": 72},
+        {"path": "failure_count", "equals": 0},
+        {"path": "results.0.mutation", "equals": "add_data_validation"},
+        {"path": "results.0.compared_page_count", "equals": 1},
+        {"path": "results.71.mutation", "equals": "copy_remove_sheet"},
+        {"path": "results.71.compared_page_count", "equals": 1}
+      ]
+    },
+    {
+      "name": "random_corpus_holdout_20_renderable_18_neutral_render_equivalence",
+      "path": "/tmp/wolfxl-random-holdout-20-renderable-18-neutral-render-equivalence-20260511.json",
+      "producer": "uv run --no-sync python scripts/audit_ooxml_no_visual_change_render_equivalence.py /tmp/wolfxl-render-excel-random-holdout-20-renderable-18-neutral-features-20260511/render-compare-report.json --mutation add_data_validation --mutation add_conditional_formatting --mutation add_remove_chart --mutation copy_remove_sheet --timeout 120 --strict > /tmp/wolfxl-random-holdout-20-renderable-18-neutral-render-equivalence-20260511.json",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "render_engine", "equals": "excel"},
+        {"path": "excel_print_area", "equals": "$A$1:$K$80"},
+        {"path": "mutations", "equals": ["add_data_validation", "add_conditional_formatting", "add_remove_chart", "copy_remove_sheet"]},
+        {"path": "observed_mutations", "equals": ["add_conditional_formatting", "add_data_validation", "add_remove_chart", "copy_remove_sheet"]},
+        {"path": "missing_mutations", "equals": []},
+        {"path": "result_count", "equals": 72},
+        {"path": "passed_count", "equals": 72},
+        {"path": "failure_count", "equals": 0},
+        {"path": "inconclusive_count", "equals": 0},
+        {"path": "skipped_count", "equals": 0},
+        {"path": "results.0.status", "equals": "passed"},
+        {"path": "results.71.status", "equals": "passed"}
+      ]
+    },
+    {
       "name": "random_corpus_holdout_10_smoke_mutation_report",
       "path": "/tmp/wolfxl-ooxml-fidelity-mutations-random-holdout-10-smoke-20260511/report.json",
       "producer": "rm -rf /tmp/wolfxl-random-corpus-holdout-10-stage-20260511 /tmp/wolfxl-ooxml-fidelity-mutations-random-holdout-10-smoke-20260511 && uv run --no-sync python scripts/audit_ooxml_random_corpus_holdout.py /tmp/wolfxl-corpus-portfolio-buckets-with-fed-aea-20260511.json --sample-size 10 --min-sample-size 10 --min-sources 5 --seed wolfxl-random-holdout-20260511-v1 --stage-dir /tmp/wolfxl-random-corpus-holdout-10-stage-20260511 --strict > /tmp/wolfxl-random-corpus-holdout-10-staged-20260511.json && uv run --no-sync python scripts/run_ooxml_fidelity_mutations.py /tmp/wolfxl-random-corpus-holdout-10-stage-20260511 --output-dir /tmp/wolfxl-ooxml-fidelity-mutations-random-holdout-10-smoke-20260511 --mutation no_op --mutation marker_cell --skip-invalid-source > /tmp/wolfxl-ooxml-fidelity-mutations-random-holdout-10-smoke-20260511.stdout.json",

--- a/Plans/real-world-excel-fidelity-gap-discovery.md
+++ b/Plans/real-world-excel-fidelity-gap-discovery.md
@@ -583,6 +583,19 @@ embedded list-box/button-control clicks, and timeline month click after a
 WolfXL `add_remove_chart` save. Broader mouse-click slicer/timeline variants
 remain open.
 
+Latest random-render increment: a deterministic 20-workbook random holdout
+using seed `wolfxl-random-holdout-render-20260511-v15` stages cleanly across
+14 source reports and records its renderability boundary at
+`/tmp/wolfxl-random-holdout-20-render-boundary-20260511.json`. Microsoft Excel
+PDF export fails with parameter error `-50` for two sampled workbooks after the
+neutral feature edits, so those two are explicitly excluded from the
+renderable-subset claim instead of being counted as passes. The renderable
+18-workbook subset then passes Microsoft Excel neutral render-equivalence for
+`add_data_validation`, `add_conditional_formatting`, `add_remove_chart`, and
+`copy_remove_sheet`: `/tmp/wolfxl-random-holdout-20-renderable-18-neutral-render-equivalence-20260511.json`
+is `ready=true` with 72 passed, 0 failures, and 0 inconclusive under the
+recorded `$A$1:$K$80` temporary print-area clamp.
+
 Follow-up runner hardening: click-level Excel UI probes now fail before opening
 Excel when macOS reports the screen is locked. This keeps blocked local UI
 sessions from being misread as workbook corruption or slow Excel launch

--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -190,6 +190,9 @@ REQUIRED_CURRENT_EVIDENCE_REPORTS = (
     "current_excel_16_108_delete_first_col_broad_external_tool_slicer_boundary",
     "random_corpus_holdout_50",
     "random_corpus_holdout_50_quick_mutation_report",
+    "random_corpus_holdout_20_render_boundary",
+    "random_corpus_holdout_20_renderable_18_neutral_render_smoke",
+    "random_corpus_holdout_20_renderable_18_neutral_render_equivalence",
     "random_corpus_holdout_10_smoke_mutation_report",
     "random_corpus_holdout_10_add_data_validation_render_smoke",
     "random_corpus_holdout_10_add_data_validation_render_equivalence",
@@ -305,6 +308,10 @@ OPEN_REQUIREMENTS = (
             "separately proves add-data-validation, add-conditional-formatting, "
             "add-remove-chart, and copy-remove-sheet render equivalence on 10 "
             "sampled workbooks spanning eight source reports, "
+            "and proves the same four neutral feature edits on an 18-workbook "
+            "Excel-renderable subset of a 20-workbook random holdout spanning "
+            "14 source reports, with the two Excel PDF-export boundary "
+            "workbooks recorded separately, "
             "plus expected "
             "visual-delta evidence for "
             "marker-cell, style-cell, insert-tail-row/column, move-marker-range, "

--- a/scripts/summarize_ooxml_render_boundary.py
+++ b/scripts/summarize_ooxml_render_boundary.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Summarize a render-compare boundary without treating failures as passes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Optional
+
+
+def summarize_render_boundary(stage_report: Path, render_report: Path) -> dict:
+    stage_payload = json.loads(stage_report.read_text())
+    render_payload = json.loads(render_report.read_text())
+    failures = [
+        result
+        for result in render_payload.get("results", [])
+        if result.get("status") == "failed"
+    ]
+    failures_by_fixture: dict[str, list[str]] = defaultdict(list)
+    failure_messages_by_fixture: dict[str, set[str]] = defaultdict(set)
+    for failure in failures:
+        fixture = str(failure.get("fixture", ""))
+        mutation = str(failure.get("mutation", ""))
+        message = str(failure.get("message", "")).strip()
+        failures_by_fixture[fixture].append(mutation)
+        if message:
+            failure_messages_by_fixture[fixture].add(message)
+
+    status_counts = Counter(
+        str(result.get("status")) for result in render_payload.get("results", [])
+    )
+    selected_count = int(stage_payload.get("selected_count", 0))
+    render_results = render_payload.get("results", [])
+    observed_fixtures = {
+        str(result.get("fixture", ""))
+        for result in render_results
+        if isinstance(result, dict) and result.get("fixture")
+    }
+    consistency_issues = []
+    if selected_count < len(observed_fixtures):
+        consistency_issues.append(
+            "selected_count is smaller than the number of unique fixtures "
+            "observed in the render report"
+        )
+    if selected_count < len(failures_by_fixture):
+        consistency_issues.append(
+            "selected_count is smaller than the number of unique failed fixtures"
+        )
+    renderable_subset_count = max(0, selected_count - len(failures_by_fixture))
+    ready = (
+        bool(stage_payload.get("ready"))
+        and renderable_subset_count > 0
+        and not consistency_issues
+    )
+    return {
+        "ready": ready,
+        "purpose": (
+            "Boundary record for a deterministic random-holdout Excel render "
+            "attempt before pinning a renderable subset."
+        ),
+        "holdout_report": str(stage_report),
+        "render_report": str(render_report),
+        "seed": stage_payload.get("seed"),
+        "sample_size": stage_payload.get("sample_size"),
+        "selected_count": selected_count,
+        "selected_source_count": stage_payload.get("selected_source_count"),
+        "selected_bucket_counts": stage_payload.get("selected_bucket_counts"),
+        "render_engine": render_payload.get("render_engine"),
+        "excel_print_area": render_payload.get("excel_print_area"),
+        "mutations": render_payload.get("mutations"),
+        "render_result_count": render_payload.get("result_count"),
+        "render_failure_count": render_payload.get("failure_count"),
+        "status_counts": dict(sorted(status_counts.items())),
+        "observed_fixture_count": len(observed_fixtures),
+        "consistency_issues": consistency_issues,
+        "excluded_from_renderable_subset": [
+            {
+                "fixture": fixture,
+                "mutations": mutations,
+                "failure_messages": sorted(failure_messages_by_fixture[fixture]),
+            }
+            for fixture, mutations in sorted(failures_by_fixture.items())
+        ],
+        "renderable_subset_count": renderable_subset_count,
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("stage_report", type=Path)
+    parser.add_argument("render_report", type=Path)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero unless a non-empty renderable subset is available.",
+    )
+    args = parser.parse_args(argv)
+    report = summarize_render_boundary(args.stage_report, args.render_report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if args.strict and not report["ready"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -93,6 +93,15 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
     assert "random_corpus_holdout_50_quick_mutation_report" in (
         completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
     )
+    assert "random_corpus_holdout_20_render_boundary" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "random_corpus_holdout_20_renderable_18_neutral_render_smoke" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "random_corpus_holdout_20_renderable_18_neutral_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
     assert "random_corpus_holdout_10_smoke_mutation_report" in (
         completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
     )

--- a/tests/test_ooxml_render_boundary_summary.py
+++ b/tests/test_ooxml_render_boundary_summary.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_boundary_module() -> ModuleType:
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "summarize_ooxml_render_boundary.py"
+    )
+    spec = importlib.util.spec_from_file_location("summarize_ooxml_render_boundary", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+boundary = _load_boundary_module()
+
+
+def test_render_boundary_summary_records_failed_fixture_once(tmp_path: Path) -> None:
+    stage_report = tmp_path / "stage.json"
+    render_report = tmp_path / "render.json"
+    stage_report.write_text(
+        json.dumps(
+            {
+                "ready": True,
+                "seed": "seed-v1",
+                "sample_size": 3,
+                "selected_count": 3,
+                "selected_source_count": 2,
+                "selected_bucket_counts": {"excel_authored": 3},
+            }
+        )
+    )
+    render_report.write_text(
+        json.dumps(
+            {
+                "render_engine": "excel",
+                "excel_print_area": "$A$1:$K$80",
+                "mutations": ["add_data_validation", "copy_remove_sheet"],
+                "result_count": 6,
+                "failure_count": 2,
+                "results": [
+                    {
+                        "fixture": "a.xlsx",
+                        "mutation": "add_data_validation",
+                        "status": "sampled_rendered",
+                    },
+                    {
+                        "fixture": "a.xlsx",
+                        "mutation": "copy_remove_sheet",
+                        "status": "sampled_rendered",
+                    },
+                    {
+                        "fixture": "b.xlsx",
+                        "mutation": "add_data_validation",
+                        "status": "failed",
+                        "message": "Microsoft Excel PDF export failed: parameter error -50",
+                    },
+                    {
+                        "fixture": "b.xlsx",
+                        "mutation": "copy_remove_sheet",
+                        "status": "failed",
+                        "message": "Microsoft Excel PDF export failed: parameter error -50",
+                    },
+                    {
+                        "fixture": "c.xlsx",
+                        "mutation": "add_data_validation",
+                        "status": "sampled_rendered",
+                    },
+                    {
+                        "fixture": "c.xlsx",
+                        "mutation": "copy_remove_sheet",
+                        "status": "sampled_rendered",
+                    },
+                ],
+            }
+        )
+    )
+
+    report = boundary.summarize_render_boundary(stage_report, render_report)
+
+    assert report["ready"] is True
+    assert report["selected_count"] == 3
+    assert report["render_failure_count"] == 2
+    assert report["renderable_subset_count"] == 2
+    assert report["observed_fixture_count"] == 3
+    assert report["consistency_issues"] == []
+    assert report["status_counts"] == {"failed": 2, "sampled_rendered": 4}
+    assert report["excluded_from_renderable_subset"] == [
+        {
+            "fixture": "b.xlsx",
+            "mutations": ["add_data_validation", "copy_remove_sheet"],
+            "failure_messages": [
+                "Microsoft Excel PDF export failed: parameter error -50"
+            ],
+        }
+    ]
+
+
+def test_render_boundary_summary_flags_inconsistent_fixture_counts(
+    tmp_path: Path,
+) -> None:
+    stage_report = tmp_path / "stage.json"
+    render_report = tmp_path / "render.json"
+    stage_report.write_text(
+        json.dumps(
+            {
+                "ready": True,
+                "seed": "seed-v1",
+                "sample_size": 0,
+                "selected_count": 0,
+                "selected_source_count": 0,
+                "selected_bucket_counts": {},
+            }
+        )
+    )
+    render_report.write_text(
+        json.dumps(
+            {
+                "render_engine": "excel",
+                "mutations": ["add_data_validation"],
+                "result_count": 1,
+                "failure_count": 1,
+                "results": [
+                    {
+                        "fixture": "unexpected.xlsx",
+                        "mutation": "add_data_validation",
+                        "status": "failed",
+                        "message": "ImageMagick compare failed",
+                    }
+                ],
+            }
+        )
+    )
+
+    report = boundary.summarize_render_boundary(stage_report, render_report)
+
+    assert report["ready"] is False
+    assert report["renderable_subset_count"] == 0
+    assert report["observed_fixture_count"] == 1
+    assert report["consistency_issues"] == [
+        "selected_count is smaller than the number of unique fixtures "
+        "observed in the render report",
+        "selected_count is smaller than the number of unique failed fixtures",
+    ]
+    assert report["excluded_from_renderable_subset"] == [
+        {
+            "fixture": "unexpected.xlsx",
+            "mutations": ["add_data_validation"],
+            "failure_messages": ["ImageMagick compare failed"],
+        }
+    ]


### PR DESCRIPTION
## Summary
- pin a deterministic 20-workbook random-holdout Excel render boundary report
- record the two Excel PDF-export boundary workbooks instead of counting them as passes
- require and document the 18-workbook renderable-subset neutral render-equivalence evidence across add-data-validation, add-conditional-formatting, add-remove-chart, and copy-remove-sheet

## Validation
- uv run --no-sync pytest tests/test_ooxml_render_boundary_summary.py tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q
- uv run --no-sync python scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict > /tmp/wolfxl-current-evidence-bundle-audit-random-holdout-20-render-committed-20260511.json
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-current-random-holdout-20-render-committed-20260511.json

## Evidence
- bundle audit: ready=true, report_count=466, issue_count=0
- completion guard: current_supported_claim_ready=true, exhaustive_claim_ready=false, missing_requirement_count=4
