### PR TITLE
Require expanded render evidence in completion guard

### DIFF
--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -142,6 +142,10 @@ REQUIRED_CURRENT_EVIDENCE_REPORTS = (
     "census_sitc_renderable_gap_radar",
     "census_sitc_renderable_quick_mutation_report",
     "census_sitc_renderable_neutral_render_equivalence",
+    "fintech_hackathon_demo_neutral_render_equivalence",
+    "fed_aea_papers_neutral_render_smoke",
+    "fed_aea_papers_copy_chart_render_equivalence",
+    "codexaudit_qoe_sample_add_dv_render_equivalence",
     "synthgl_recursive_gap_radar",
     "umya_test_files_gap_radar",
     "umya_test_files_quick_plus_structural_mutation_coverage",
@@ -344,6 +348,9 @@ OPEN_REQUIREMENTS = (
             "Excel-renderable subset of a 20-workbook random holdout spanning "
             "14 source reports, with the two Excel PDF-export boundary "
             "workbooks recorded separately, "
+            "plus fintech-hackathon finance-demo neutral equivalence, Fed AEA "
+            "research-data neutral render smoke and copy/chart equivalence, "
+            "and CodexAudit QoE add-data-validation equivalence, "
             "plus expected "
             "visual-delta evidence for "
             "marker-cell, style-cell, insert-tail-row/column, move-marker-range, "

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -89,6 +89,18 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
     assert "census_sitc_renderable_neutral_render_equivalence" in (
         completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
     )
+    assert "fintech_hackathon_demo_neutral_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "fed_aea_papers_neutral_render_smoke" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "fed_aea_papers_copy_chart_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
+    assert "codexaudit_qoe_sample_add_dv_render_equivalence" in (
+        completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
+    )
     assert "random_corpus_holdout_50" in completion.REQUIRED_CURRENT_EVIDENCE_REPORTS
     assert "random_corpus_holdout_50_quick_mutation_report" in (
         completion.REQUIRED_CURRENT_EVIDENCE_REPORTS


### PR DESCRIPTION
## Summary
- require four already-pinned Excel render evidence reports in the current completion guard
- update the render-equivalence open gap wording to include fintech demo, Fed AEA, and CodexAudit QoE side evidence
- add regression assertions for the newly required render evidence reports

## Verification
- uv run --no-sync pytest tests/test_ooxml_completion_claim.py tests/test_ooxml_evidence_bundle.py -q
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence
