### PR TITLE
Surface current target readiness in completion audit

### DIFF
--- a/scripts/audit_ooxml_completion_claim.py
+++ b/scripts/audit_ooxml_completion_claim.py
@@ -723,6 +723,8 @@ def _ui_interaction_coverage_matrix(
         "missing_expected_mutation_probe_pairs": missing_expected_pairs,
         "unpassed_expected_mutation_probe_pair_count": len(unpassed_expected_pairs),
         "unpassed_expected_mutation_probe_pairs": unpassed_expected_pairs,
+        "current_target_ready": not missing_expected_pairs
+        and not unpassed_expected_pairs,
         "boundary_only_expected_mutation_probe_pair_count": len(
             boundary_only_expected_pairs
         ),
@@ -894,6 +896,8 @@ def _render_equivalence_coverage_matrix(
         "missing_expected_mutations": missing_expected_mutations,
         "unpassed_expected_mutation_count": len(unpassed_expected_mutations),
         "unpassed_expected_mutations": unpassed_expected_mutations,
+        "current_target_ready": not missing_expected_mutations
+        and not unpassed_expected_mutations,
         "multi_mutation_report_count": len(multi_mutation_reports),
         "multi_mutation_reports": sorted(multi_mutation_reports),
         "issue_report_count": len(issue_reports),
@@ -1068,8 +1072,10 @@ def _open_requirements(bundle_audit: dict) -> list[dict]:
                 f"buckets, with {render_matrix['missing_expected_mutation_count']} "
                 "missing expected buckets and "
                 f"{render_matrix['unpassed_expected_mutation_count']} unpassed "
-                "expected buckets. This is substantial feature-specific visual "
-                "evidence, but the high-risk feature-edit universe is still "
+                "expected buckets; current target ready is "
+                f"{render_matrix['current_target_ready']}. This is substantial "
+                "feature-specific visual evidence, but the high-risk feature-edit "
+                "universe is still "
                 "open-ended, so it does not yet prove semantic visual equivalence "
                 "for every high-risk edit."
             )
@@ -1093,7 +1099,10 @@ def _open_requirements(bundle_audit: dict) -> list[dict]:
                 "embedded-control, and prompt variants remain unexhausted; the "
                 "current target matrix is missing "
                 f"{interaction_evidence['coverage_matrix']['missing_expected_mutation_probe_pair_count']} "
-                "expected mutation/probe pairs."
+                "expected mutation/probe pairs, has "
+                f"{interaction_evidence['coverage_matrix']['unpassed_expected_mutation_probe_pair_count']} "
+                "unpassed expected mutation/probe pairs, and current target ready "
+                f"is {interaction_evidence['coverage_matrix']['current_target_ready']}."
             )
     return requirements
 

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -648,6 +648,49 @@ def test_render_equivalence_coverage_matrix_reports_current_target_gaps() -> Non
     assert report["current_target_ready"] is False
 
 
+def test_render_equivalence_coverage_matrix_marks_current_target_ready() -> None:
+    report = completion._render_equivalence_coverage_matrix(
+        [
+            {
+                "name": "copy_remove_sheet_render_equivalence",
+                "path": "/tmp/copy-remove-sheet-render-equivalence.json",
+                "checks": [
+                    {"path": "ready", "actual": True, "passed": True},
+                    {"path": "render_engine", "actual": "excel", "passed": True},
+                    {"path": "mutation", "actual": "copy_remove_sheet", "passed": True},
+                    {"path": "result_count", "actual": 4, "passed": True},
+                    {"path": "passed_count", "actual": 4, "passed": True},
+                    {"path": "failure_count", "actual": 0, "passed": True},
+                    {"path": "inconclusive_count", "actual": 0, "passed": True},
+                    {"path": "non_comparable_count", "actual": 0, "passed": True},
+                    {"path": "skipped_count", "actual": 0, "passed": True},
+                ],
+            },
+            {
+                "name": "rename_first_sheet_render_equivalence",
+                "path": "/tmp/rename-first-sheet-render-equivalence.json",
+                "checks": [
+                    {"path": "ready", "actual": True, "passed": True},
+                    {"path": "render_engine", "actual": "excel", "passed": True},
+                    {"path": "mutation", "actual": "rename_first_sheet", "passed": True},
+                    {"path": "result_count", "actual": 2, "passed": True},
+                    {"path": "passed_count", "actual": 2, "passed": True},
+                    {"path": "failure_count", "actual": 0, "passed": True},
+                    {"path": "inconclusive_count", "actual": 0, "passed": True},
+                    {"path": "non_comparable_count", "actual": 0, "passed": True},
+                    {"path": "skipped_count", "actual": 0, "passed": True},
+                ],
+            },
+        ],
+        expected_mutations=("copy_remove_sheet", "rename_first_sheet"),
+    )
+
+    assert report["observed_expected_mutation_count"] == 2
+    assert report["missing_expected_mutations"] == []
+    assert report["unpassed_expected_mutations"] == []
+    assert report["current_target_ready"] is True
+
+
 def test_render_equivalence_coverage_matrix_rejects_non_excel_clean_target() -> None:
     report = completion._render_equivalence_coverage_matrix(
         [
@@ -752,6 +795,41 @@ def test_ui_interaction_coverage_matrix_groups_mutations_and_probe_statuses() ->
         "known_boundary_failed": 0,
         "diagnostic_failed": 1,
     }
+
+
+def test_ui_interaction_coverage_matrix_marks_current_target_ready() -> None:
+    report = completion._ui_interaction_coverage_matrix(
+        [
+            {
+                "name": "excel_ui_interaction_source_probe",
+                "checks": [
+                    {"path": "results.0.probe", "actual": "slicer_selection_state"},
+                    {"path": "results.0.status", "actual": "passed"},
+                    {"path": "results.1.probe", "actual": "pivot_refresh_state"},
+                    {"path": "results.1.status", "actual": "passed"},
+                ],
+            },
+            {
+                "name": "excel_ui_interaction_copy_remove_sheet_probe",
+                "checks": [
+                    {"path": "mutation", "actual": "copy_remove_sheet"},
+                    {"path": "results.0.probe", "actual": "slicer_selection_state"},
+                    {"path": "results.0.status", "actual": "passed"},
+                    {"path": "results.1.probe", "actual": "pivot_refresh_state"},
+                    {"path": "results.1.status", "actual": "passed"},
+                ],
+            },
+        ],
+        known_boundary_reports=set(),
+        diagnostic_reports=set(),
+        expected_mutations=("source", "copy_remove_sheet"),
+        expected_probes=("slicer_selection_state", "pivot_refresh_state"),
+    )
+
+    assert report["observed_expected_mutation_probe_pair_count"] == 4
+    assert report["missing_expected_mutation_probe_pairs"] == []
+    assert report["unpassed_expected_mutation_probe_pairs"] == []
+    assert report["current_target_ready"] is True
 
 
 def test_completion_claim_audit_requires_named_current_evidence_reports(

--- a/tests/test_ooxml_completion_claim.py
+++ b/tests/test_ooxml_completion_claim.py
@@ -86,9 +86,13 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
     assert render_requirement["evidence"]["coverage_matrix"][
         "unpassed_expected_mutation_count"
     ] == 0
+    assert render_requirement["evidence"]["coverage_matrix"][
+        "current_target_ready"
+    ] is False
     assert "current render-equivalence target matrix covers 1 of" in (
         render_requirement["reason"]
     )
+    assert "current target ready is False" in render_requirement["reason"]
     assert "missing expected buckets" in render_requirement["reason"]
     interaction_requirement = next(
         requirement
@@ -131,6 +135,10 @@ def test_completion_claim_audit_supports_current_claim_but_not_exhaustive_claim(
             "observed_expected_mutation_probe_pair_count"
         ]
     )
+    assert interaction_requirement["evidence"]["coverage_matrix"][
+        "current_target_ready"
+    ] is False
+    assert "current target ready is False" in interaction_requirement["reason"]
     assert interaction_requirement["evidence"]["target_status"] == (
         "open_unbounded_click_level_variant_universe"
     )
@@ -637,6 +645,7 @@ def test_render_equivalence_coverage_matrix_reports_current_target_gaps() -> Non
         "excel_or_native_clean_report_count"
     ] == 1
     assert report["unpassed_expected_mutations"] == ["rename_first_sheet"]
+    assert report["current_target_ready"] is False
 
 
 def test_render_equivalence_coverage_matrix_rejects_non_excel_clean_target() -> None:
@@ -667,6 +676,7 @@ def test_render_equivalence_coverage_matrix_rejects_non_excel_clean_target() -> 
         "excel_or_native_clean_report_count"
     ] == 0
     assert report["unpassed_expected_mutations"] == ["copy_remove_sheet"]
+    assert report["current_target_ready"] is False
 
 
 def test_ui_interaction_coverage_matrix_groups_mutations_and_probe_statuses() -> None:


### PR DESCRIPTION
## Summary
- add explicit current_target_ready booleans to render-equivalence and UI-interaction target matrices
- surface those booleans in the open-requirement reason text
- keep the exhaustive claim false while making clear that current render/UI target matrices have no missing or unpassed expected rows

## Verification
- uv run --no-sync pytest tests/test_ooxml_completion_claim.py
- uv run --no-sync python -m py_compile scripts/audit_ooxml_completion_claim.py
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-current-target-ready-20260512.json

Strict audit summary: current supported claim ready=true, exhaustive claim ready=false, render_current_target_ready=true, ui_current_target_ready=true.