### PR TITLE
Pin timeline copy-sheet native render proof

### DIFF
--- a/Plans/ooxml-current-evidence-bundle.json
+++ b/Plans/ooxml-current-evidence-bundle.json
@@ -3648,6 +3648,68 @@
       ]
     },
     {
+      "name": "timeline_slicer_sidecar_excel_render_copy_first_sheet_all_pages",
+      "path": "/tmp/wolfxl-render-excel-timeline-copy-first-sheet-all-pages-20260511.json",
+      "producer": "rm -rf /tmp/wolfxl-timeline-copy-first-sheet-render-input-20260511 /tmp/wolfxl-render-excel-timeline-copy-first-sheet-all-pages-20260511 /tmp/wolfxl-render-excel-timeline-copy-first-sheet-all-pages-20260511.json && mkdir -p /tmp/wolfxl-timeline-copy-first-sheet-render-input-20260511 && cp tests/fixtures/external_oracle/real-excel-timeline-slicer.xlsx /tmp/wolfxl-timeline-copy-first-sheet-render-input-20260511/ && (osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_render_compare.py /tmp/wolfxl-timeline-copy-first-sheet-render-input-20260511 --output-dir /tmp/wolfxl-render-excel-timeline-copy-first-sheet-all-pages-20260511 --render-engine excel --timeout 240 --max-pages-per-fixture 80 --mutation copy_first_sheet > /tmp/wolfxl-render-excel-timeline-copy-first-sheet-all-pages-20260511.json",
+      "expect": [
+        {"path": "result_count", "equals": 1},
+        {"path": "failure_count", "equals": 0},
+        {"path": "render_engine", "equals": "excel"},
+        {"path": "mutations", "equals": ["copy_first_sheet"]},
+        {"path": "results.0.fixture", "equals": "real-excel-timeline-slicer.xlsx"},
+        {"path": "results.0.status", "equals": "rendered"},
+        {"path": "results.0.page_count", "equals": 74},
+        {"path": "results.0.compared_page_count", "equals": 74}
+      ]
+    },
+    {
+      "name": "timeline_slicer_native_excel_copy_baseline_metadata",
+      "path": "/tmp/wolfxl-excel-native-copy-timeline-baseline-20260512.json",
+      "producer": "Native Microsoft Excel copy baseline: open tests/fixtures/external_oracle/real-excel-timeline-slicer.xlsx, run Excel's copy worksheet command for worksheet 1 after worksheet 2, save as /tmp/wolfxl-excel-native-copy-timeline-20260512/excel-native-copy.xlsx, then inspect xl/workbook.xml to verify the source has 2 sheets and the native baseline has 3 sheets including Pivot Table (2).",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "source_sheet_count", "equals": 2},
+        {"path": "native_copy_sheet_count", "equals": 3},
+        {"path": "source_sheets", "equals": ["Pivot Table", "Data_Table "]},
+        {"path": "native_copy_sheets", "equals": ["Pivot Table", "Data_Table ", "Pivot Table (2)"]},
+        {"path": "copied_sheet_name", "equals": "Pivot Table (2)"}
+      ]
+    },
+    {
+      "name": "timeline_slicer_native_excel_copy_render_baseline",
+      "path": "/tmp/wolfxl-render-excel-native-copy-timeline-20260512.json",
+      "producer": "(osascript -e 'tell application \"Microsoft Excel\" to quit' >/dev/null 2>&1 || true) && uv run --no-sync python scripts/run_ooxml_render_compare.py /tmp/wolfxl-excel-native-copy-timeline-20260512 --output-dir /tmp/wolfxl-render-excel-native-copy-timeline-20260512 --render-engine excel --timeout 240 --max-pages-per-fixture 80 > /tmp/wolfxl-render-excel-native-copy-timeline-20260512.json",
+      "expect": [
+        {"path": "result_count", "equals": 1},
+        {"path": "failure_count", "equals": 0},
+        {"path": "render_engine", "equals": "excel"},
+        {"path": "mutations", "equals": ["no_op"]},
+        {"path": "results.0.fixture", "equals": "excel-native-copy.xlsx"},
+        {"path": "results.0.status", "equals": "passed"},
+        {"path": "results.0.page_count", "equals": 74},
+        {"path": "results.0.compared_page_count", "equals": 74},
+        {"path": "results.0.max_normalized_rmse", "equals": 0.0}
+      ]
+    },
+    {
+      "name": "timeline_slicer_copy_first_sheet_native_excel_page_multiset_equivalence",
+      "path": "/tmp/wolfxl-timeline-copy-first-sheet-excel-native-page-multiset-equivalence-20260512.json",
+      "producer": "uv run --no-sync python scripts/audit_ooxml_render_page_multiset_equivalence.py /tmp/wolfxl-render-excel-timeline-copy-first-sheet-all-pages-20260511/render-compare-report.json /tmp/wolfxl-render-excel-native-copy-timeline-20260512/render-compare-report.json --left-mutation copy_first_sheet --right-mutation no_op --left-prefix after --right-prefix before --strict > /tmp/wolfxl-timeline-copy-first-sheet-excel-native-page-multiset-equivalence-20260512.json",
+      "expect": [
+        {"path": "ready", "equals": true},
+        {"path": "left_mutation", "equals": "copy_first_sheet"},
+        {"path": "right_mutation", "equals": "no_op"},
+        {"path": "result_count", "equals": 1},
+        {"path": "passed_count", "equals": 1},
+        {"path": "failure_count", "equals": 0},
+        {"path": "inconclusive_count", "equals": 0},
+        {"path": "results.0.status", "equals": "passed"},
+        {"path": "results.0.left_page_count", "equals": 74},
+        {"path": "results.0.right_page_count", "equals": 74},
+        {"path": "results.0.differing_hash_count", "equals": 0}
+      ]
+    },
+    {
       "name": "slicer_shared_two_pivots_sidecar_excel_render_rename_sheet",
       "path": "/tmp/wolfxl-render-excel-slicer-shared-two-pivots-rename-sheet-20260509.json",
       "producer": "uv run --no-sync python scripts/run_ooxml_render_compare.py tests/fixtures/slicer_timeline_variants --render-engine excel --mutation rename_first_sheet --output-dir /tmp/wolfxl-render-excel-slicer-shared-two-pivots-rename-sheet-20260509 --timeout 240 --max-pages-per-fixture 4 --page-selection first-and-last-pages > /tmp/wolfxl-render-excel-slicer-shared-two-pivots-rename-sheet-20260509.json",

--- a/Plans/real-world-excel-fidelity-gap-discovery.md
+++ b/Plans/real-world-excel-fidelity-gap-discovery.md
@@ -71,21 +71,25 @@ Latest IRS SOI public-statistics sidecar evidence adds `/tmp/wolfxl-corpus-bucke
 
 Latest BEA GDP public-statistics sidecar evidence adds `/tmp/wolfxl-corpus-buckets-bea-gdp-20260511.json`, `/tmp/wolfxl-gap-radar-bea-gdp-20260511.json`, and `/tmp/wolfxl-ooxml-fidelity-mutations-bea-gdp-quick-20260511/report.json`: 4 downloaded public Bureau of Economic Analysis GDP workbooks, 0 skipped, gap radar clear, and 24 no-op, marker-cell, style-cell, copy-remove-sheet, add-data-validation, and add-conditional-formatting mutation results with 0 failures. The aggregate portfolio now reaches 28 source reports and 389 readable workbooks while still covering all required diversity buckets.
 
-Latest shared pivot-slicer copy-first-sheet follow-up adds `/tmp/wolfxl-slicer-shared-two-pivots-copy-first-sheet-excel-native-page-multiset-equivalence-20260510.json`: `ready=true`, 72 WolfXL-rendered pages and 72 native-Excel-copy rendered pages have identical page-image multisets. The earlier direct page-1-to-page-71 comparison remains intentionally unpinned because Excel itself assigns the copied-slicer shading state to the opposite printed page; the native-baseline audit proves WolfXL matches desktop Excel's rendered output set without weakening the stricter direct-equivalence audit.
-
-Timeline copy-first-sheet native-baseline follow-up remains open. A 2026-05-11
-exploratory WolfXL render at
-`/tmp/wolfxl-render-excel-timeline-copy-first-sheet-all-pages-20260511/render-compare-report.json`
-successfully rendered 74 pages for `copy_first_sheet` on
-`real-excel-timeline-slicer.xlsx`, but the attempted native Microsoft Excel copy
-baseline was not reliable enough to pin: one rendered baseline at
-`/tmp/wolfxl-render-excel-manual-copy-timeline-20260511c-clean/render-compare-report.json`
-still had only 71 pages, matching the source workbook rather than a confirmed
-copied-sheet workbook, and the resulting page-multiset audit
-`/tmp/wolfxl-timeline-copy-first-sheet-excel-native-page-multiset-equivalence-20260511.json`
-failed. Treat that as an inconclusive baseline-generation failure, not proof of
-a WolfXL render mismatch, until Excel automation can verify the baseline
-workbook has the copied timeline sheet.
+Latest copy-first-sheet native-baseline follow-up adds two high-risk slicer/timeline
+page-multiset proofs. The shared pivot-slicer audit at
+`/tmp/wolfxl-slicer-shared-two-pivots-copy-first-sheet-excel-native-page-multiset-equivalence-20260510.json`
+is `ready=true`: 72 WolfXL-rendered pages and 72 native-Excel-copy rendered pages
+have identical page-image multisets. The timeline audit at
+`/tmp/wolfxl-timeline-copy-first-sheet-excel-native-page-multiset-equivalence-20260512.json`
+is also `ready=true`: 74 WolfXL-rendered pages and 74 native-Excel-copy rendered
+pages have identical page-image multisets. The timeline native baseline is now
+verified before rendering by
+`/tmp/wolfxl-excel-native-copy-timeline-baseline-20260512.json`, which records
+the source workbook's two sheets and the native Excel copy baseline's three
+sheets, including `Pivot Table (2)`. An earlier 2026-05-11 timeline baseline
+attempt rendered only 71 pages because the saved workbook still had the original
+two sheets; that artifact remains an invalid baseline-generation failure, not a
+WolfXL render mismatch. The older direct page-order comparisons remain
+intentionally unpinned where Excel itself assigns copied slicer/timeline state to
+different printed pages; the native-baseline multiset audits prove WolfXL
+matches desktop Excel's rendered output set without weakening the stricter
+direct-equivalence audits.
 
 Latest PowerView sidecar increment: `/tmp/wolfxl-ui-interaction-add-dv-powerview-open-readonly-20260510/interactive-probe-report.json` opens the Contoso PowerPivot/PowerView workbook after a WolfXL `add_data_validation` save, clicks `Open as Read-Only`, and verifies the PowerView marker remains present. The strict audit `/tmp/wolfxl-ui-interaction-evidence-add-dv-powerview-open-readonly-20260510.json` is `ready=true` with 1 report, 1 fixture, and 0 incomplete reports.
 


### PR DESCRIPTION
## Summary
- pin a valid native Microsoft Excel copy baseline for the timeline slicer workbook
- add the full-page timeline copy-first-sheet render and native baseline render to the evidence bundle
- record that WolfXL and native Excel produce identical 74-page render multisets for the timeline copy-first-sheet case
- update the fidelity plan note to retire the prior invalid 71-page baseline as a baseline-generation failure

## Verification
- uv run --no-sync python scripts/audit_ooxml_evidence_bundle.py Plans/ooxml-current-evidence-bundle.json --strict > /tmp/wolfxl-evidence-bundle-timeline-copy-first-native-20260512.json
- uv run --no-sync python scripts/audit_ooxml_completion_claim.py Plans/ooxml-current-evidence-bundle.json --strict-current-evidence > /tmp/wolfxl-completion-timeline-copy-first-native-20260512.json

Completion audit remains intentionally not exhaustive: current_supported_claim_ready=true, exhaustive_claim_ready=false, missing_requirement_count=3.